### PR TITLE
docs: record tablet figma transfer artifacts

### DIFF
--- a/docs/superpowers/artifacts/2026-05-20-invoice-review-command-center/2026-06-09-tablet-transfer-artifact-pack.md
+++ b/docs/superpowers/artifacts/2026-05-20-invoice-review-command-center/2026-06-09-tablet-transfer-artifact-pack.md
@@ -16,15 +16,17 @@ This repo note records that shared source so FE-1101 closure does not depend on 
 The shared Make workspace contains the three approved tablet artifacts for FE-1101:
 
 - `Tablet Today`
-  - Make source reference: `src/app/components/TabletToday.tsx`
+  - Figma Make workspace source file: `ERTkTps2LKHza6lyyUPsRp / src/app/components/TabletToday.tsx`
 - `Tablet This Month`
-  - Make source reference: `src/app/components/TabletThisMonth.tsx`
+  - Figma Make workspace source file: `ERTkTps2LKHza6lyyUPsRp / src/app/components/TabletThisMonth.tsx`
 - `Tablet Invoice Detail`
-  - Make source reference: `src/app/components/TabletInvoiceDetail.tsx`
+  - Figma Make workspace source file: `ERTkTps2LKHza6lyyUPsRp / src/app/components/TabletInvoiceDetail.tsx`
+
+These are Figma Make internal source-file references surfaced from the shared workspace. They are not files in this repository.
 
 ## Supporting Transfer Evidence Present In The Make Workspace
 
-The Figma Make context also exposes supporting FE-1101 handoff materials:
+The Figma Make context also exposes the following FE-1101 handoff materials inside the same shared workspace. These files are referenced within that Figma Make workspace and are not stored in this repository:
 
 - `FE-1101_FIGMA_TRANSFER_GUIDE.md`
 - `README_TABLET_FRAMES.md`
@@ -33,7 +35,7 @@ The Figma Make context also exposes supporting FE-1101 handoff materials:
 - `FE-1101_DESIGN_COMPARISON.md`
 - `TABLET_DESIGN_NOTES.md`
 
-These files are part of the same Make workspace and reinforce that the tablet work was completed as a documented handoff package, not just as isolated visual experiments.
+These workspace-referenced materials reinforce that the tablet work was completed as a documented handoff package, not just as isolated visual experiments.
 
 ## Source-Of-Truth Statement
 

--- a/docs/superpowers/artifacts/2026-05-20-invoice-review-command-center/2026-06-09-tablet-transfer-artifact-pack.md
+++ b/docs/superpowers/artifacts/2026-05-20-invoice-review-command-center/2026-06-09-tablet-transfer-artifact-pack.md
@@ -1,0 +1,46 @@
+# Tablet Transfer Artifact Pack
+
+Date: 2026-06-09
+Related issues: `#63`, `#73`, `#76`
+
+## Summary
+
+The canonical source for all three tablet completion artifacts lives in one shared Figma Make workspace:
+
+- [Create Tablet Review Frames](https://www.figma.com/make/ERTkTps2LKHza6lyyUPsRp/Create-Tablet-Review-Frames?t=hSvSYAJhHMpZP8jw-1)
+
+This repo note records that shared source so FE-1101 closure does not depend on chat history or ad hoc links.
+
+## Approved Tablet Artifacts
+
+The shared Make workspace contains the three approved tablet artifacts for FE-1101:
+
+- `Tablet Today`
+  - Make source reference: `src/app/components/TabletToday.tsx`
+- `Tablet This Month`
+  - Make source reference: `src/app/components/TabletThisMonth.tsx`
+- `Tablet Invoice Detail`
+  - Make source reference: `src/app/components/TabletInvoiceDetail.tsx`
+
+## Supporting Transfer Evidence Present In The Make Workspace
+
+The Figma Make context also exposes supporting FE-1101 handoff materials:
+
+- `FE-1101_FIGMA_TRANSFER_GUIDE.md`
+- `README_TABLET_FRAMES.md`
+- `FE-1101_COMPLETION_SUMMARY.md`
+- `FE-1101_VALIDATION_CHECKLIST.md`
+- `FE-1101_DESIGN_COMPARISON.md`
+- `TABLET_DESIGN_NOTES.md`
+
+These files are part of the same Make workspace and reinforce that the tablet work was completed as a documented handoff package, not just as isolated visual experiments.
+
+## Source-Of-Truth Statement
+
+As of 2026-06-09, the tablet source of truth is the shared Figma Make workspace above. This artifact pack does not claim that the tablet frames were copied into the main `Invoice Review Command Center Prototype` file.
+
+That distinction matters for FE-1104: the repo should explicitly say when tablet evidence remains anchored in the Make workspace rather than implying a transfer to the main prototype file.
+
+## Remaining Precision Gap
+
+The shared Make URL is sufficient to identify the tablet artifact pack. If Milestone 11 closeout later requires per-frame node-specific URLs, those should be added as a follow-up refinement under `#76`.

--- a/docs/superpowers/artifacts/2026-05-20-invoice-review-command-center/README.md
+++ b/docs/superpowers/artifacts/2026-05-20-invoice-review-command-center/README.md
@@ -20,6 +20,7 @@ This directory is the repo-backed source package for the invoice review prototyp
 - Decision actions button polish: [2026-05-26-decision-actions-button-polish.md](./2026-05-26-decision-actions-button-polish.md)
 - Lower cards containment fix: [2026-05-26-lower-cards-containment-fix.md](./2026-05-26-lower-cards-containment-fix.md)
 - Desktop quality pass: Facts and supporting signals: [2026-05-26-desktop-quality-pass-facts-and-signals.md](./2026-05-26-desktop-quality-pass-facts-and-signals.md)
+- Tablet transfer artifact pack: [2026-06-09-tablet-transfer-artifact-pack.md](./2026-06-09-tablet-transfer-artifact-pack.md)
 - E12 gap audit: [2026-05-31-e12-gap-audit.md](./2026-05-31-e12-gap-audit.md)
 - Stakeholder approval screenshot pack: [approval-pack/README.md](./approval-pack/README.md)
 - Desktop Today reproducibility guide: [desktop-today-reproducibility.md](./desktop-today-reproducibility.md)
@@ -30,6 +31,8 @@ This directory is the repo-backed source package for the invoice review prototyp
 
 - File URL: [Invoice Review Command Center Prototype](https://www.figma.com/design/ORTJPMYSjhBp8TZGZktrWf)
 - File key: `ORTJPMYSjhBp8TZGZktrWf`
+- Tablet Make workspace: [Create Tablet Review Frames](https://www.figma.com/make/ERTkTps2LKHza6lyyUPsRp/Create-Tablet-Review-Frames?t=hSvSYAJhHMpZP8jw-1)
+- Tablet Make key: `ERTkTps2LKHza6lyyUPsRp`
 
 ## Approval Frames
 
@@ -67,6 +70,6 @@ This directory is the repo-backed source package for the invoice review prototyp
 
 ## Deferred UX Issues
 
-- Tablet-specific layout tuning is deferred to [FE-1101](https://github.com/vgeshiktor/invoices-platform/issues/63). The current approval package covers desktop and mobile only.
+- Tablet evidence is now anchored in [2026-06-09-tablet-transfer-artifact-pack.md](./2026-06-09-tablet-transfer-artifact-pack.md), which records the shared Figma Make workspace for `Tablet Today`, `Tablet This Month`, and `Tablet Invoice Detail`. Any remaining FE-1101 closeout work is traceability polish, not missing concept coverage.
 - Duplicate-pair comparison messaging can be expanded in a dedicated comparison state under [FE-1004](https://github.com/vgeshiktor/invoices-platform/issues/62) if stakeholder review asks for a side-by-side original versus receipt experience.
 - The latest E12 audit in [2026-05-31-e12-gap-audit.md](./2026-05-31-e12-gap-audit.md) narrows the remaining milestone blockers to `#63` tablet review and `#64` mobile-detail readability/accessibility cleanup.


### PR DESCRIPTION
## Summary
- add a repo-backed tablet transfer artifact pack for FE-1101
- record the canonical shared Figma Make workspace for all three tablet artifacts
- update the Milestone 11 artifact index so tablet coverage is no longer described as missing

## Issues
- Closes #73
- Advances #76
- Supports #63

## Verification
- `git diff --check`
- pre-commit hooks during `git commit`
- `pytest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a tablet transfer artifact pack documenting tablet-focused artifacts and their canonical design workspace.
  * Updated invoice review command center references with tablet artifact links and workspace info.
  * Clarified source-of-truth boundaries for tablet frames versus the main prototype and noted a remaining traceability/URL precision gap to address later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->