### PR TITLE
docs: record mobile detail figma evidence

### DIFF
--- a/docs/superpowers/artifacts/2026-05-20-invoice-review-command-center/2026-06-10-mobile-detail-fix-evidence.md
+++ b/docs/superpowers/artifacts/2026-05-20-invoice-review-command-center/2026-06-10-mobile-detail-fix-evidence.md
@@ -1,0 +1,28 @@
+# Mobile Detail Fix Evidence
+
+Date: 2026-06-10
+Related issues: `#64`, `#74`
+
+## Summary
+
+The canonical source for the FE-1102 mobile-detail fix evidence is the shared Figma Make workspace:
+
+- [Create Tablet Review Frames](https://www.figma.com/make/ERTkTps2LKHza6lyyUPsRp/Create-Tablet-Review-Frames?t=pw3zZFXibcUmRzC9-1)
+
+This repo note records the final mobile-detail artifact link provided for Milestone 11 closeout.
+
+## Final Mobile Detail Artifact
+
+- Artifact name: `Mobile Invoice Detail`
+- Make source reference: `src/app/components/MobileInvoiceDetail.tsx`
+- Supporting handoff note present in the Make workspace: `FE-1102_MOBILE_DETAIL_FIX.md`
+
+## Evidence Statement
+
+The shared Make workspace is the durable design reference for the FE-1102 closeout pass in this repo trail. It demonstrates that the mobile-detail artifact and its dedicated fix note exist in one canonical design source, rather than relying on chat history or temporary screenshots.
+
+## Scope Of This Evidence
+
+This note records the final shared Figma link and the design artifact names exposed by the Make context. It does not claim that the mobile-detail fix was transferred into the main `Invoice Review Command Center Prototype` file.
+
+If Milestone 11 closeout later requires a node-specific design URL in the main prototype file, that should be added as a follow-up refinement to the FE-1105 evidence trail.

--- a/docs/superpowers/artifacts/2026-05-20-invoice-review-command-center/README.md
+++ b/docs/superpowers/artifacts/2026-05-20-invoice-review-command-center/README.md
@@ -20,6 +20,7 @@ This directory is the repo-backed source package for the invoice review prototyp
 - Decision actions button polish: [2026-05-26-decision-actions-button-polish.md](./2026-05-26-decision-actions-button-polish.md)
 - Lower cards containment fix: [2026-05-26-lower-cards-containment-fix.md](./2026-05-26-lower-cards-containment-fix.md)
 - Desktop quality pass: Facts and supporting signals: [2026-05-26-desktop-quality-pass-facts-and-signals.md](./2026-05-26-desktop-quality-pass-facts-and-signals.md)
+- Mobile detail fix evidence: [2026-06-10-mobile-detail-fix-evidence.md](./2026-06-10-mobile-detail-fix-evidence.md)
 - Tablet transfer artifact pack: [2026-06-09-tablet-transfer-artifact-pack.md](./2026-06-09-tablet-transfer-artifact-pack.md)
 - E12 gap audit: [2026-05-31-e12-gap-audit.md](./2026-05-31-e12-gap-audit.md)
 - Stakeholder approval screenshot pack: [approval-pack/README.md](./approval-pack/README.md)
@@ -31,6 +32,8 @@ This directory is the repo-backed source package for the invoice review prototyp
 
 - File URL: [Invoice Review Command Center Prototype](https://www.figma.com/design/ORTJPMYSjhBp8TZGZktrWf)
 - File key: `ORTJPMYSjhBp8TZGZktrWf`
+- Shared Make workspace: [Create Tablet Review Frames](https://www.figma.com/make/ERTkTps2LKHza6lyyUPsRp/Create-Tablet-Review-Frames?t=pw3zZFXibcUmRzC9-1)
+- Shared Make key: `ERTkTps2LKHza6lyyUPsRp`
 - Tablet Make workspace: [Create Tablet Review Frames](https://www.figma.com/make/ERTkTps2LKHza6lyyUPsRp/Create-Tablet-Review-Frames?t=hSvSYAJhHMpZP8jw-1)
 - Tablet Make key: `ERTkTps2LKHza6lyyUPsRp`
 
@@ -42,6 +45,7 @@ This directory is the repo-backed source package for the invoice review prototyp
 - Mobile Detail: [node 6:521](https://www.figma.com/design/ORTJPMYSjhBp8TZGZktrWf?node-id=6-521)
 - Screenshot pack: [approval-pack/README.md](./approval-pack/README.md)
 - Review note: the mobile detail frame was rebuilt on 2026-05-24 to resolve collapsed-width layout bugs and strengthen review-state logic.
+- Review note: the repo-backed FE-1102 evidence trail is captured in [2026-06-10-mobile-detail-fix-evidence.md](./2026-06-10-mobile-detail-fix-evidence.md), using the shared Make workspace as the canonical final artifact source.
 - Review note: all four approval frames were structurally rebuilt on 2026-05-25 so the geometry audit reports zero visible tiny-width containers.
 - Review note: a second 2026-05-25 pass preserved desktop structure, rebuilt mobile for feed-and-scroll behavior, and added 360x780 QA validation frames.
 - Review note: a focused 2026-05-25 desktop pass corrected only the stats-card description containment while preserving the rest of the dashboard.


### PR DESCRIPTION
## Summary
- add a repo-backed FE-1102 mobile-detail evidence note
- record the shared Figma Make workspace as the canonical final artifact source for the mobile detail fix
- update the Milestone 11 artifact index to link the mobile evidence trail

## Issues
- Closes #74
- Supports #64

## Verification
- `git diff --check`
- pre-commit hooks during `git commit`
- `pytest`
