### PR TITLE
docs: close out Milestone 11 evidence trail

### DIFF
--- a/docs/superpowers/artifacts/2026-05-20-invoice-review-command-center/2026-06-02-remaining-design-prompts.md
+++ b/docs/superpowers/artifacts/2026-05-20-invoice-review-command-center/2026-06-02-remaining-design-prompts.md
@@ -1,0 +1,103 @@
+# Remaining Design Prompts
+
+Date: 2026-06-02
+Scope: Remaining Milestone 11 design follow-up for `#63` and `#64`
+
+## FE-1101 Tablet Validation Note
+
+The missing tablet concept work is no longer blank. The user provided tablet-design links that resolve to one shared Figma Make workspace:
+
+- Tablet Today: [Create Tablet Review Frames](https://www.figma.com/make/ERTkTps2LKHza6lyyUPsRp/Create-Tablet-Review-Frames?fullscreen=1&t=4NFWOG5jwbujrT2A-1&code-node-id=0-9)
+- Tablet This Month: [Create Tablet Review Frames](https://www.figma.com/make/ERTkTps2LKHza6lyyUPsRp/Create-Tablet-Review-Frames?fullscreen=1&t=4NFWOG5jwbujrT2A-1&code-node-id=0-9)
+
+Validation note:
+
+- Both links point to the same Figma Make file.
+- The Make context includes `TabletToday.tsx` and `TabletThisMonth.tsx`.
+- Treat `#63` as a validation and finalization pass, not a from-scratch tablet ideation task.
+
+## FE-1102 Prompt
+
+Use this prompt for the remaining readability and accessibility cleanup on the mobile detail design:
+
+```text
+Open the existing Figma file "Invoice Review Command Center Prototype" and run a focused readability/accessibility pass on the mobile invoice detail frame.
+
+Target frame:
+- Mobile Invoice Detail: node 6:521
+
+Known issue from the repo audit:
+- Inside the "Decision required" card, the small "EVIDENCE" eyebrow label sits too high and visually collides with the main decision block.
+
+Primary goal:
+- Fix the mobile detail readability issue without changing the product logic or losing the current premium dense-finance feel.
+
+Constraints:
+- Keep the current mobile flow concept:
+  - full-screen detail
+  - metadata-first hierarchy
+  - sticky primary action area
+  - facts and source content below the decision block
+- Do not redesign the screen from scratch.
+- Preserve the existing hierarchy where the operator can quickly answer:
+  1. why this invoice is here
+  2. what is risky or missing
+  3. what the next correct action is
+
+Review and polish:
+- section label placement
+- vertical spacing inside the Decision required card
+- text collision risk
+- chip readability
+- type sizing for dense fields
+- contrast and separation between labels, body text, and supporting notes
+- sticky action area clarity
+- safe spacing above the bottom action bar
+
+Required acceptance criteria:
+- No overlapping or visually colliding text in the Decision required card.
+- Section labels must read as deliberate structure, not accidental floating text.
+- Dense content must stay readable on mobile without looking oversized or loose.
+- The primary CTA must still dominate the action area.
+- The final frame should remain visually consistent with the approved desktop/mobile system.
+
+Output:
+- Update the existing mobile detail frame or create a clearly named revised variant in the same Figma file.
+- Keep the revised frame easy to reference later as the FE-1102 completion artifact.
+```
+
+## Combined Prompt
+
+Use this when the same pass should finish both remaining issues:
+
+```text
+Finish the remaining Milestone 11 design gaps using the existing command-center design and the provided tablet Make workspace.
+
+Remaining issues:
+- FE-1101: validate and finalize the provided tablet-responsive command-center frames
+- FE-1102: fix the mobile detail readability/accessibility defect in node 6:521
+
+Approved anchors in the main design file:
+- Desktop Today: node 6:45
+- Desktop This Month: node 6:303
+- Mobile Today: node 6:439
+- Mobile Invoice Detail: node 6:521
+
+Provided tablet source:
+- https://www.figma.com/make/ERTkTps2LKHza6lyyUPsRp/Create-Tablet-Review-Frames?fullscreen=1&t=4NFWOG5jwbujrT2A-1&code-node-id=0-9
+
+What to do:
+1. Validate and finalize the provided tablet Today and tablet This Month states so tablet coverage is explicit and reviewable.
+2. Repair the mobile detail typography/spacing issue in the Decision required card.
+3. Recheck chip readability, CTA prominence, and section boundaries after the updates.
+
+Non-goals:
+- no broad visual redesign
+- no new product features
+- no changes that weaken the exception-first review flow
+
+Definition of done:
+- tablet coverage exists as a clear artifact for FE-1101
+- the mobile detail readability issue is visibly resolved for FE-1102
+- the resulting frames still look like one coherent invoice review command-center system
+```

--- a/docs/superpowers/artifacts/2026-05-20-invoice-review-command-center/2026-06-11-e12-closeout.md
+++ b/docs/superpowers/artifacts/2026-05-20-invoice-review-command-center/2026-06-11-e12-closeout.md
@@ -1,0 +1,60 @@
+# E12 Closeout Note
+
+Date: 2026-06-11
+Scope: Final repo-backed Milestone 11 closeout status for `#63`, `#64`, `#65`, and `#66`
+
+## Summary
+
+Milestone 11 now has explicit repo-backed evidence for the remaining E12 work:
+
+- FE-1101 tablet coverage is documented in [2026-06-09-tablet-transfer-artifact-pack.md](./2026-06-09-tablet-transfer-artifact-pack.md)
+- FE-1102 mobile-detail readability fix evidence is documented in [2026-06-10-mobile-detail-fix-evidence.md](./2026-06-10-mobile-detail-fix-evidence.md)
+- FE-1103 screenshot-pack delivery is documented in [approval-pack/README.md](./approval-pack/README.md)
+- FE-1104 closeout and deferral precision are documented in this note
+
+## Issue Status
+
+### FE-1101
+
+Status: complete for Milestone 11 closeout.
+
+The repo now records the shared Figma Make workspace and the tablet artifact references used to finish the tablet-inclusive review pass. The remaining gap described in the 2026-05-31 audit is no longer a missing concept or missing evidence problem.
+
+### FE-1102
+
+Status: complete for Milestone 11 closeout.
+
+The repo now records the final shared Make workspace reference and the dedicated mobile-detail fix handoff note. The 2026-05-31 readability blocker is superseded by the 2026-06-10 evidence note.
+
+### FE-1103
+
+Status: complete.
+
+The approval screenshot pack is already durable and repo-backed under [approval-pack](./approval-pack/README.md).
+
+### FE-1104
+
+Status: complete as a milestone closeout task.
+
+The remaining responsibility for FE-1104 was to either fix critical unresolved UX defects or convert any non-critical residue into explicit follow-up knowledge. The repo now does that explicitly:
+
+- the 2026-05-31 gap audit remains as the historical pre-fix snapshot
+- the 2026-06-02 prompt handoff remains as the historical execution prompt set
+- the 2026-06-09 and 2026-06-10 evidence notes record the completed tablet and mobile closeout trail
+
+## Non-Blocking Precision Follow-Up
+
+These are not Milestone 11 blockers:
+
+- If future traceability needs stricter proof, add node-specific URLs for the tablet and mobile-detail final artifacts.
+- If future handoff needs a single design source, document whether the final Make artifacts were transferred into the main prototype file or intentionally remain Make-anchored.
+
+## Source Ordering
+
+Use the artifact trail in this order when reviewing closeout:
+
+1. [2026-05-31-e12-gap-audit.md](./2026-05-31-e12-gap-audit.md)
+2. [2026-06-02-remaining-design-prompts.md](./2026-06-02-remaining-design-prompts.md)
+3. [2026-06-09-tablet-transfer-artifact-pack.md](./2026-06-09-tablet-transfer-artifact-pack.md)
+4. [2026-06-10-mobile-detail-fix-evidence.md](./2026-06-10-mobile-detail-fix-evidence.md)
+5. [approval-pack/README.md](./approval-pack/README.md)

--- a/docs/superpowers/artifacts/2026-05-20-invoice-review-command-center/README.md
+++ b/docs/superpowers/artifacts/2026-05-20-invoice-review-command-center/README.md
@@ -20,9 +20,11 @@ This directory is the repo-backed source package for the invoice review prototyp
 - Decision actions button polish: [2026-05-26-decision-actions-button-polish.md](./2026-05-26-decision-actions-button-polish.md)
 - Lower cards containment fix: [2026-05-26-lower-cards-containment-fix.md](./2026-05-26-lower-cards-containment-fix.md)
 - Desktop quality pass: Facts and supporting signals: [2026-05-26-desktop-quality-pass-facts-and-signals.md](./2026-05-26-desktop-quality-pass-facts-and-signals.md)
+- Remaining design prompts: [2026-06-02-remaining-design-prompts.md](./2026-06-02-remaining-design-prompts.md)
 - Mobile detail fix evidence: [2026-06-10-mobile-detail-fix-evidence.md](./2026-06-10-mobile-detail-fix-evidence.md)
 - Tablet transfer artifact pack: [2026-06-09-tablet-transfer-artifact-pack.md](./2026-06-09-tablet-transfer-artifact-pack.md)
 - E12 gap audit: [2026-05-31-e12-gap-audit.md](./2026-05-31-e12-gap-audit.md)
+- E12 closeout note: [2026-06-11-e12-closeout.md](./2026-06-11-e12-closeout.md)
 - Stakeholder approval screenshot pack: [approval-pack/README.md](./approval-pack/README.md)
 - Desktop Today reproducibility guide: [desktop-today-reproducibility.md](./desktop-today-reproducibility.md)
 - Desktop Today reproducibility snapshot: [desktop-today-reproducibility.json](./desktop-today-reproducibility.json)
@@ -74,6 +76,6 @@ This directory is the repo-backed source package for the invoice review prototyp
 
 ## Deferred UX Issues
 
-- Tablet evidence is now anchored in [2026-06-09-tablet-transfer-artifact-pack.md](./2026-06-09-tablet-transfer-artifact-pack.md), which records the shared Figma Make workspace for `Tablet Today`, `Tablet This Month`, and `Tablet Invoice Detail`. Any remaining FE-1101 closeout work is traceability polish, not missing concept coverage.
+- FE-1101, FE-1102, and FE-1103 now have explicit repo-backed evidence. Use [2026-06-11-e12-closeout.md](./2026-06-11-e12-closeout.md) as the milestone closeout source of truth.
 - Duplicate-pair comparison messaging can be expanded in a dedicated comparison state under [FE-1004](https://github.com/vgeshiktor/invoices-platform/issues/62) if stakeholder review asks for a side-by-side original versus receipt experience.
-- The latest E12 audit in [2026-05-31-e12-gap-audit.md](./2026-05-31-e12-gap-audit.md) narrows the remaining milestone blockers to `#63` tablet review and `#64` mobile-detail readability/accessibility cleanup.
+- If future traceability work needs tighter precision, add node-specific design URLs and document whether the final tablet/mobile evidence remains Make-anchored or is transferred into the main prototype file.


### PR DESCRIPTION
## Summary
- add a final E12 closeout note for FE-1101 through FE-1104
- restore the historical remaining-prompts handoff into the repo artifact trail
- update the Milestone 11 artifact README to point at the final evidence and closeout sources

## Test Plan
- [x] pytest -q tests/test_invoice_finders.py tests/test_graph_invoice_helpers.py
- [x] commit hook pytest during git commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design prompts documentation for tablet validation and mobile readability/accessibility improvements
  * Added milestone closeout documentation tracking completion status for recent work items
  * Updated central documentation index with new artifact references and updated guidance on deferred issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->