### PR TITLE
chore: ignore generated report outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ dist/
 **/.idea
 **/.vscode
 .token_cache.bin
+report*
+!reports/
+reports/*
+!reports/.gitkeep
 invoices*
 !tests/fixtures/invoices
 !tests/fixtures/invoices/*


### PR DESCRIPTION
## Summary
- ignore generated `report*` outputs in the repo root
- keep the `reports/` directory tracked with `reports/.gitkeep`
- leave local generated report artifacts out of git

## Test Plan
- [x] pre-commit hooks during git commit
- [x] pytest via commit hook