### PR TITLE
[codex] harden report invariants and monthly summaries

### DIFF
--- a/.ai/tasks/2026-06-15-domain-invariants.md
+++ b/.ai/tasks/2026-06-15-domain-invariants.md
@@ -1,0 +1,22 @@
+# Task Packet Template
+Desired outcome:
+Define executable domain invariants for duplicate suppression, monthly idempotence, visible partial failure, explicit money rounding, multilingual preservation, quarantine visibility, report redaction, and explicit date/time semantics.
+Explicit non-goals:
+Do not redesign the full ingestion/report architecture or introduce a database/queue model.
+Relevant docs/files:
+- `docs/ARCHITECTURE.md`
+- `docs/SECURITY-AND-DATA-HANDLING.md`
+- `apps/workers-py/src/invplatform/cli/monthly_invoices.py`
+- `apps/workers-py/src/invplatform/cli/invoices_report.py`
+- `tests/test_monthly_invoices.py`
+- `tests/test_graph_invoice_finder_e2e.py`
+Required validation:
+- targeted `pytest` for invariant coverage
+- rerun the affected monthly/report test slices
+Known decisions:
+- invariants should be executable as tests, not prose-only guidance
+- keep changes proportional to the current CLI-first, file-based system
+Missing decisions:
+- `TBD` if stronger cross-provider semantic dedupe than current hash/stem/text behavior is needed later
+Reasoning level: `ai:deep`
+max initial files: `6`

--- a/.ai/tasks/2026-06-15-pr79-review-comments.md
+++ b/.ai/tasks/2026-06-15-pr79-review-comments.md
@@ -1,0 +1,26 @@
+# PR 79 Review Comments
+Desired outcome:
+- Address all actionable unresolved review comments on PR 79 without regressing invoice parsing behavior.
+
+Explicit non-goals:
+- Resolve GitHub threads or post review replies.
+- Refactor unrelated invoice parsing paths.
+
+Relevant docs/files:
+- `apps/workers-py/src/invplatform/cli/invoices_report.py`
+- `tests/test_invoices_report_utils.py`
+- `AGENTS.md`
+- `PLANS.md`
+
+Required validation:
+- `pytest tests/test_invoices_report_utils.py -k 'prefers_positive_summary_rate or skips_iso_date_tokens'`
+
+Known decisions:
+- Work in the current checkout to preserve existing in-progress local changes.
+- Limit fixes to the two unresolved Codex review threads on PR 79.
+
+Missing decisions:
+- None.
+
+Reasoning level: `ai:review`
+max initial files: `6`

--- a/apps/workers-py/src/invplatform/cli/invoices_report.py
+++ b/apps/workers-py/src/invplatform/cli/invoices_report.py
@@ -87,6 +87,7 @@ def sanitize_report_value(value):
         return {key: sanitize_report_value(item) for key, item in value.items()}
     return value
 
+
 KNOWN_VENDOR_MARKERS: Tuple[Tuple[str, str], ...] = (
     ("יול ימר", "רמי לוי תקשורת"),
     ("פרטנר", 'חברת פרטנר תקשורת בע"מ'),
@@ -367,7 +368,9 @@ def normalize_date_token(token: str, default_day: Optional[int] = None) -> Optio
 def is_date_like_token(token: Optional[str]) -> bool:
     if not token:
         return False
-    candidate = token.strip().replace("\\", "-").replace("/", "-").replace(".", "-").replace(",", "-")
+    candidate = (
+        token.strip().replace("\\", "-").replace("/", "-").replace(".", "-").replace(",", "-")
+    )
     if not re.fullmatch(r"\d{1,4}(?:-\d{1,2}){1,2}", candidate):
         return False
     return normalize_date_token(candidate) is not None

--- a/apps/workers-py/src/invplatform/cli/invoices_report.py
+++ b/apps/workers-py/src/invplatform/cli/invoices_report.py
@@ -4,6 +4,7 @@ import argparse
 import calendar
 from collections import Counter
 import csv
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 import hashlib
 import html
 import json
@@ -32,6 +33,59 @@ except ModuleNotFoundError:
 
 
 Amount = Optional[float]
+MONEY_QUANTUM = Decimal("0.01")
+REPORT_SECRET_PATTERNS: Tuple[Tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(r"Authorization:\s*Bearer\s+\S+", flags=re.IGNORECASE),
+        "[REDACTED_AUTH_HEADER]",
+    ),
+    (
+        re.compile(r"Bearer\s+\S+", flags=re.IGNORECASE),
+        "[REDACTED_BEARER_TOKEN]",
+    ),
+    (
+        re.compile(r"[^\s'\",;]*(?:credentials|token)\.json"),
+        "[REDACTED_CREDENTIAL_PATH]",
+    ),
+    (
+        re.compile(r"[^\s'\",;]*\.msal[\w.-]*\.bin|[^\s'\",;]*msal[_\w.-]*cache[\w.-]*\.bin"),
+        "[REDACTED_TOKEN_CACHE_PATH]",
+    ),
+)
+
+
+def _to_decimal(value: float | int) -> Decimal:
+    return Decimal(str(value))
+
+
+def round_money(value: float | int | None) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        quantized = _to_decimal(value).quantize(MONEY_QUANTUM, rounding=ROUND_HALF_UP)
+    except (InvalidOperation, ValueError):
+        return None
+    return float(quantized)
+
+
+def sanitize_report_text(text: str) -> str:
+    sanitized = text
+    for pattern, replacement in REPORT_SECRET_PATTERNS:
+        sanitized = pattern.sub(replacement, sanitized)
+    return sanitized
+
+
+def sanitize_report_value(value):
+    if isinstance(value, float):
+        rounded = round_money(value)
+        return rounded if rounded is not None else value
+    if isinstance(value, str):
+        return sanitize_report_text(value)
+    if isinstance(value, list):
+        return [sanitize_report_value(item) for item in value]
+    if isinstance(value, dict):
+        return {key: sanitize_report_value(item) for key, item in value.items()}
+    return value
 
 KNOWN_VENDOR_MARKERS: Tuple[Tuple[str, str], ...] = (
     ("יול ימר", "רמי לוי תקשורת"),
@@ -128,9 +182,12 @@ class InvoiceRecord:
     municipal: Optional[bool] = None
     duplicate_hash: Optional[str] = None
 
+    def to_public_dict(self) -> Dict[str, object]:
+        return sanitize_report_value(asdict(self))
+
     def to_csv_row(self, fields: Sequence[str]) -> List[str]:
         row = []
-        data = asdict(self)
+        data = self.to_public_dict()
         for field in fields:
             value = data.get(field)
             if isinstance(value, float):
@@ -305,6 +362,15 @@ def normalize_date_token(token: str, default_day: Optional[int] = None) -> Optio
         day = min(day, calendar.monthrange(year, month)[1])
         return date(year, month, day).strftime("%Y-%m-%d")
     return None
+
+
+def is_date_like_token(token: Optional[str]) -> bool:
+    if not token:
+        return False
+    candidate = token.strip().replace("\\", "-").replace("/", "-").replace(".", "-").replace(",", "-")
+    if not re.fullmatch(r"\d{1,4}(?:-\d{1,2}){1,2}", candidate):
+        return False
+    return normalize_date_token(candidate) is not None
 
 
 def extract_period_info(text: str) -> Tuple[Optional[str], Optional[str], Optional[str]]:
@@ -948,7 +1014,7 @@ def infer_invoice_id(lines: List[str], text: str) -> Optional[str]:
 
     def add_candidate(value: Optional[str], priority: int) -> None:
         val = (value or "").strip()
-        if not val:
+        if not val or is_date_like_token(val):
             return
         cleaned = re.sub(r"[^\d]", "", val)
         candidates.append((priority, cleaned or val))
@@ -1569,13 +1635,19 @@ def extract_vat_rate_from_text(text: Optional[str]) -> Optional[float]:
         rf"{vat_marker}[^%\d]{{0,15}}?([\d.,]+)\s*%",
         r"VAT[^%\d]{0,15}?([\d.,]+)\s*%",
     ]
+    matches: List[Tuple[int, float]] = []
     for pattern in patterns:
-        match = re.search(pattern, text, flags=re.IGNORECASE)
-        if match:
+        for match in re.finditer(pattern, text, flags=re.IGNORECASE):
             value = parse_number(match.group(1))
             if value is not None:
-                return round(value, 2)
-    return None
+                matches.append((match.start(1), round(value, 2)))
+    if not matches:
+        return None
+    matches.sort(key=lambda item: item[0])
+    positive = [value for _, value in matches if value > 0]
+    if positive:
+        return positive[-1]
+    return matches[-1][1]
 
 
 def infer_totals(
@@ -2123,7 +2195,7 @@ def generate_report(
 def write_json(records: List[InvoiceRecord], output_path: Path) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with output_path.open("w", encoding="utf-8") as fh:
-        json.dump([asdict(rec) for rec in records], fh, ensure_ascii=False, indent=2)
+        json.dump([rec.to_public_dict() for rec in records], fh, ensure_ascii=False, indent=2)
 
 
 def write_csv(records: List[InvoiceRecord], output_path: Path) -> None:
@@ -2169,7 +2241,8 @@ def write_summary_csv(
         if value is None:
             return ""
         if isinstance(value, float):
-            return f"{value:.2f}"
+            rounded = round_money(value)
+            return f"{rounded:.2f}" if rounded is not None else ""
         return str(value)
 
     fields = [
@@ -2509,8 +2582,8 @@ def compute_report_totals(
     records: Sequence[InvoiceRecord],
 ) -> Dict[str, Dict[str, Optional[float] | int]]:
     def stats_for(field: str) -> Dict[str, Optional[float]]:
-        total = 0.0
-        abs_total = 0.0
+        total = Decimal("0")
+        abs_total = Decimal("0")
         count = 0
         missing = 0
         zero = 0
@@ -2526,9 +2599,10 @@ def compute_report_totals(
             if value == 0:
                 zero += 1
                 continue
+            decimal_value = _to_decimal(value)
             count += 1
-            total += value
-            abs_total += abs(value)
+            total += decimal_value
+            abs_total += abs(decimal_value)
             if value < 0:
                 negative += 1
             else:
@@ -2537,17 +2611,21 @@ def compute_report_totals(
                 min_val = value
             if max_val is None or value > max_val:
                 max_val = value
-        avg = round(total / count, 2) if count else None
+        avg = (
+            float((total / Decimal(count)).quantize(MONEY_QUANTUM, rounding=ROUND_HALF_UP))
+            if count
+            else None
+        )
         return {
-            "sum": round(total, 2),
-            "abs_sum": round(abs_total, 2),
+            "sum": float(total.quantize(MONEY_QUANTUM, rounding=ROUND_HALF_UP)),
+            "abs_sum": float(abs_total.quantize(MONEY_QUANTUM, rounding=ROUND_HALF_UP)),
             "count": count,
             "missing": missing,
             "zero": zero,
             "negative": negative,
             "positive": positive,
-            "min": min_val,
-            "max": max_val,
+            "min": round_money(min_val),
+            "max": round_money(max_val),
             "avg": avg,
         }
 

--- a/apps/workers-py/src/invplatform/cli/monthly_invoices.py
+++ b/apps/workers-py/src/invplatform/cli/monthly_invoices.py
@@ -41,6 +41,8 @@ PROJECT_SRC = Path(__file__).resolve().parents[2]
 DEFAULT_PYTHON = os.environ.get("PYTHON") or sys.executable
 SKIP_DIRS = {"_tmp", "quarantine", "duplicates"}
 HAVE_PYMUPDF = getattr(domain_pdf, "HAVE_PYMUPDF", False)
+SUMMARY_TIMEZONE = "UTC"
+SUMMARY_INTERVAL_SEMANTICS = "[start_date, end_date)"
 
 # Ensure direct execution works without exporting PYTHONPATH first.
 if str(PROJECT_SRC) not in sys.path:
@@ -398,11 +400,24 @@ def write_summary(
     dedupe: Dict[str, Dict[str, int]],
     stage_timings: Dict[str, object],
 ) -> None:
+    failed_providers = [r.name for r in results if r.returncode != 0]
+    successful_providers = [r.name for r in results if r.returncode == 0]
+    if failed_providers and successful_providers:
+        status = "partial_failure"
+    elif failed_providers:
+        status = "failure"
+    else:
+        status = "success"
     summary = {
+        "status": status,
+        "timezone": SUMMARY_TIMEZONE,
+        "date_interval_semantics": SUMMARY_INTERVAL_SEMANTICS,
         "start_date": start_date,
         "end_date": end_date,
         "label": label,
         "consolidated_dir": str(dest_dir),
+        "successful_providers": successful_providers,
+        "failed_providers": failed_providers,
         "providers": {
             r.name: {
                 "invoices_dir": str(r.invoices_dir),

--- a/tests/test_domain_invariants.py
+++ b/tests/test_domain_invariants.py
@@ -1,6 +1,5 @@
 import csv
 import json
-from pathlib import Path
 
 from invplatform.cli import invoices_report as report
 from invplatform.cli import monthly_invoices as monthly
@@ -34,7 +33,9 @@ def test_monthly_summary_marks_partial_failure_and_utc_half_open_window(tmp_path
         label="01_2025",
         results=[
             monthly.ProviderResult("gmail", tmp_path / "gmail", ["gmail-cmd"], 0, 1.25),
-            monthly.ProviderResult("outlook", tmp_path / "outlook", ["graph-cmd"], 1, 2.5),
+            monthly.ProviderResult(
+                "outlook", tmp_path / "outlook", ["graph-cmd"], 1, 2.5
+            ),
         ],
         consolidation={"copied": 1, "duplicates": 0, "sources": 1, "existing": 0},
         dedupe={"gmail": {"kept": 1, "moved": 0}},
@@ -50,7 +51,9 @@ def test_monthly_summary_marks_partial_failure_and_utc_half_open_window(tmp_path
     assert payload["timezone"] == "UTC"
 
 
-def test_report_outputs_round_money_redact_secrets_and_preserve_multilingual_text(tmp_path):
+def test_report_outputs_round_money_redact_secrets_and_preserve_multilingual_text(
+    tmp_path,
+):
     json_path = tmp_path / "report.json"
     csv_path = tmp_path / "report.csv"
     summary_path = tmp_path / "summary.csv"
@@ -74,7 +77,9 @@ def test_report_outputs_round_money_redact_secrets_and_preserve_multilingual_tex
 
     json_text = json_path.read_text(encoding="utf-8")
     csv_text = csv_path.read_text(encoding="utf-8")
-    summary_rows = list(csv.reader(summary_path.read_text(encoding="utf-8").splitlines()))
+    summary_rows = list(
+        csv.reader(summary_path.read_text(encoding="utf-8").splitlines())
+    )
     payload = json.loads(json_text)
 
     assert "חשבונית Invoice bilingual" in json_text

--- a/tests/test_domain_invariants.py
+++ b/tests/test_domain_invariants.py
@@ -1,0 +1,96 @@
+import csv
+import json
+from pathlib import Path
+
+from invplatform.cli import invoices_report as report
+from invplatform.cli import monthly_invoices as monthly
+
+
+def test_cross_provider_repeat_is_emitted_once_and_reruns_are_idempotent(tmp_path):
+    gmail_dir = tmp_path / "gmail"
+    outlook_dir = tmp_path / "outlook"
+    dest_dir = tmp_path / "monthly"
+    gmail_dir.mkdir()
+    outlook_dir.mkdir()
+
+    (gmail_dir / "gmail-copy.pdf").write_bytes(b"SAME-INVOICE")
+    (outlook_dir / "graph-copy.pdf").write_bytes(b"SAME-INVOICE")
+
+    first = monthly.consolidate_pdfs(dest_dir, [gmail_dir, outlook_dir])
+    second = monthly.consolidate_pdfs(dest_dir, [gmail_dir, outlook_dir])
+
+    assert first["copied"] == 1
+    assert first["duplicates"] == 1
+    assert second["copied"] == 0
+    assert len(list(dest_dir.glob("*.pdf"))) == 1
+
+
+def test_monthly_summary_marks_partial_failure_and_utc_half_open_window(tmp_path):
+    dest_dir = tmp_path / "monthly"
+    monthly.write_summary(
+        dest_dir,
+        start_date="2025-01-01",
+        end_date="2025-02-01",
+        label="01_2025",
+        results=[
+            monthly.ProviderResult("gmail", tmp_path / "gmail", ["gmail-cmd"], 0, 1.25),
+            monthly.ProviderResult("outlook", tmp_path / "outlook", ["graph-cmd"], 1, 2.5),
+        ],
+        consolidation={"copied": 1, "duplicates": 0, "sources": 1, "existing": 0},
+        dedupe={"gmail": {"kept": 1, "moved": 0}},
+        stage_timings={"total_seconds": 3.75},
+    )
+
+    payload = json.loads((dest_dir / "run_summary.json").read_text(encoding="utf-8"))
+
+    assert payload["status"] == "partial_failure"
+    assert payload["successful_providers"] == ["gmail"]
+    assert payload["failed_providers"] == ["outlook"]
+    assert payload["date_interval_semantics"] == "[start_date, end_date)"
+    assert payload["timezone"] == "UTC"
+
+
+def test_report_outputs_round_money_redact_secrets_and_preserve_multilingual_text(tmp_path):
+    json_path = tmp_path / "report.json"
+    csv_path = tmp_path / "report.csv"
+    summary_path = tmp_path / "summary.csv"
+    records = [
+        report.InvoiceRecord(
+            source_file="/private/credentials.json",
+            invoice_id="INV-001",
+            invoice_date="2025-01-15",
+            invoice_from='בזק Bezeq בע"מ',
+            invoice_for="חשבונית Invoice bilingual",
+            base_before_vat=2.005,
+            invoice_vat=1.005,
+            invoice_total=3.015,
+            notes="Authorization: Bearer secret-token from /tmp/token.json via /tmp/.msal_token_cache.bin",
+        )
+    ]
+
+    report.write_json(records, json_path)
+    report.write_csv(records, csv_path)
+    report.write_summary_csv(report.compute_report_totals(records), summary_path)
+
+    json_text = json_path.read_text(encoding="utf-8")
+    csv_text = csv_path.read_text(encoding="utf-8")
+    summary_rows = list(csv.reader(summary_path.read_text(encoding="utf-8").splitlines()))
+    payload = json.loads(json_text)
+
+    assert "חשבונית Invoice bilingual" in json_text
+    assert "בזק Bezeq" in csv_text
+    assert payload[0]["base_before_vat"] == 2.01
+    assert payload[0]["invoice_vat"] == 1.01
+    assert payload[0]["invoice_total"] == 3.02
+    assert "2.01" in csv_text
+    assert "1.01" in csv_text
+    assert "3.02" in csv_text
+    assert "Authorization" not in json_text
+    assert "Bearer secret-token" not in json_text
+    assert "credentials.json" not in json_text
+    assert "token.json" not in json_text
+    assert ".msal_token_cache.bin" not in json_text
+    assert "Authorization" not in csv_text
+    assert "token.json" not in csv_text
+    assert ".msal_token_cache.bin" not in csv_text
+    assert summary_rows[2][0] == "invoice_vat"

--- a/tests/test_graph_invoice_finder_e2e.py
+++ b/tests/test_graph_invoice_finder_e2e.py
@@ -170,9 +170,9 @@ def test_graph_invoice_finder_september_2025(
     with report_path.open("r", encoding="utf-8") as fh:
         report = json.load(fh)
     assert [row["id"] for row in report["saved"]] == [msg_id for msg_id, _ in expected]
-    assert not report[
-        "rejected"
-    ], "No invoices should be rejected in the September baseline run."
+    assert not report["rejected"], (
+        "No invoices should be rejected in the September baseline run."
+    )
     assert _StubGraphClient.last_init.get("interactive_auth") is False
 
 
@@ -360,9 +360,9 @@ def test_graph_invoice_finder_cli_flags(
 
     with report_path.open("r", encoding="utf-8") as fh:
         report = json.load(fh)
-    assert any(
-        r.get("ok") is False for r in report["report"]
-    ), "quarantine entry expected in report"
+    assert any(r.get("ok") is False for r in report["report"]), (
+        "quarantine entry expected in report"
+    )
 
     assert _StubGraphClient.last_init.get("authority") == "common"
     assert _StubGraphClient.last_init.get("interactive_auth") is True

--- a/tests/test_invoices_report_utils.py
+++ b/tests/test_invoices_report_utils.py
@@ -233,6 +233,11 @@ def test_period_due_date_and_reference_helpers():
     assert "12345" in refs
 
 
+def test_extract_vat_rate_from_text_prefers_positive_summary_rate():
+    text = 'פטור ממע"מ: 0.00%\nסה"כ מע"מ 18%'
+    assert report.extract_vat_rate_from_text(text) == pytest.approx(18.0)
+
+
 def test_classification_and_confidence_helpers():
     category, confidence, rule = report.classify_invoice(
         "חשבונית בזק שירותי אינטרנט", "בזק", False
@@ -275,6 +280,12 @@ def test_extract_period_info_supports_ranges_and_bilingual_labels_text_sample():
 def test_infer_invoice_date_fallback_grabs_first_numeric_text_sample():
     text = ARNONA_TEXT.replace("תאריך הדפסה:", "תאריך מדומה:")
     assert report.infer_invoice_date(text) == "01/09/2025"
+
+
+def test_infer_invoice_id_skips_iso_date_tokens_from_number_fallback():
+    lines = ["Date: 2026-05-14", "רפסמ"]
+    text = "\n".join(lines)
+    assert report.infer_invoice_id(lines, text) is None
 
 
 def test_infer_invoice_from_municipal_text_text_sample():


### PR DESCRIPTION
## Summary
- fix report serialization and totals handling around rounding, redaction, VAT-rate extraction, and date-like invoice-id fallbacks
- extend monthly run summaries with explicit status, provider success/failure lists, timezone, and interval semantics
- add executable invariant coverage and capture the PR79 review-follow-up in task packets

## Test Plan
- [x] `pytest -q tests/test_invoices_report_utils.py tests/test_domain_invariants.py`
- [x] `pytest -q tests/test_monthly_invoices.py -k 'partial_failure or utc_half_open_window or summary'`
- [x] full stacked verification run before publish: `make test`