### PR TITLE
[codex] Align Day 2 interoperability governance policy

### DIFF
--- a/.ai/README.md
+++ b/.ai/README.md
@@ -33,6 +33,17 @@
 - If raw/native access is necessary, record the reason in the task packet instead of silently bypassing lean-ctx.
 - If a dashboard command such as `lean-ctx gain --deep` fails, keep the normal `ctx_*` workflow and treat the failure as an upstream tooling issue unless repo work is blocked.
 
+## Interoperability Review Gate
+
+- Record the integration mode: `tool | collaborator-agent | ui-contract | commerce-deferred`.
+- Record the trust level: `official | internal | third-party-vetted | public-prototype-only`.
+- Record the data scope: `synthetic | sanitized | real-nonprod | real-prod-readonly`.
+- Prefer consuming an existing vetted tool, server, or skill before inventing custom wrappers.
+- Keep real-data external access in non-production or sanitized environments by default, and require read-only scope when possible.
+- Define the HITL approval point before side-effectful or sensitive external actions.
+- Use declarative or trusted-catalog UI contracts for generated UI work; do not treat arbitrary executable UI as acceptable output.
+- Keep AP2/UCP-style payment or procurement work in `commerce-deferred` until the repo has an explicit transaction surface and dedicated safeguards.
+
 ## Guardrails
 
 - Keep task packets short and anchored to real repo files.

--- a/.ai/evals/tasks.yaml
+++ b/.ai/evals/tasks.yaml
@@ -259,6 +259,33 @@ legacy_review_templates:
       - Governance artifacts behave like maintained repo assets rather than loose notes.
       - Review output highlights policy drift before shared workflow changes ship.
 
+  - id: day2-interoperability-governance-review
+    name: Review Day 2 interoperability governance defaults and guardrails
+    mode: production
+    reasoning_level: ai:review
+    scope: governance review of interoperability defaults across repo rules, task packets, eval templates, and repo contract tests
+    source_of_truth:
+      - AGENTS.md
+      - PLANS.md
+      - .ai/README.md
+      - .ai/task-packet-template.md
+      - .ai/evals/tasks.yaml
+      - tests/test_repo_verify_contract.py
+      - docs/SECURITY-AND-DATA-HANDLING.md
+    rubric:
+      - tool vs collaborator-agent vs ui-contract classification stays explicit
+      - HITL, trust level, and real-data scope rules remain aligned
+      - UI guidance stays declarative and trusted-catalog only
+      - deferred commerce guidance does not overclaim unsupported runtime features
+    ship_gate: interoperability governance must stay repo-backed, reviewable, and non-speculative
+    required_validation:
+      - Check that interoperability docs and templates agree on integration mode, trust level, and data scope fields.
+      - Check that HITL, read-only, and credential-handling rules do not drift from repo security guidance.
+      - Flag unsupported policy claims, missing review gates, or doc/test drift.
+    success_criteria:
+      - Governance defaults clearly separate tools, collaborator agents, UI contracts, and deferred commerce work.
+      - Repo contract tests protect the documented interoperability guardrails without adding telemetry requirements.
+
 p1_after_first_hardening_pr:
   - Add property-based tests for deduplication, date intervals, and monetary calculations.
   - Validate the OpenAPI draft against actual implementation boundaries.

--- a/.ai/task-packet-template.md
+++ b/.ai/task-packet-template.md
@@ -9,6 +9,13 @@ Working mode: `prototype | production`
 Success criteria / eval rubric:
 AI-specific review focus:
 Harness components touched:
+Integration mode: `tool | collaborator-agent | ui-contract | commerce-deferred`
+External dependency or registry:
+Trust level: `official | internal | third-party-vetted | public-prototype-only`
+Data scope: `synthetic | sanitized | real-nonprod | real-prod-readonly`
+HITL approval point:
+Write permission / read-only expectation:
+Transport/schema debugging plan:
 Reasoning level: `ai:light | ai:standard | ai:deep | ai:review`
 max initial files: `6`
 Overview/search plan:

--- a/.ai/tasks/2026-06-21-day2-interoperability-governance.md
+++ b/.ai/tasks/2026-06-21-day2-interoperability-governance.md
@@ -1,0 +1,61 @@
+# Task Packet
+Desired outcome:
+Align repo governance artifacts with Day 2 interoperability guidance without changing runtime product surfaces.
+Explicit non-goals:
+- No runtime A2A, A2UI, AP2, or UCP implementation.
+- No OpenAPI or product-doc behavior changes.
+Relevant docs/files:
+- AGENTS.md
+- PLANS.md
+- .ai/README.md
+- .ai/task-packet-template.md
+- .ai/evals/tasks.yaml
+- tests/test_repo_verify_contract.py
+- docs/SECURITY-AND-DATA-HANDLING.md
+Required validation:
+- `pytest -q tests/test_repo_verify_contract.py`
+Known decisions:
+- Working mode is production because this updates shared repo governance.
+- Scope is governance-only; protocol runtime work stays deferred.
+- Existing dirty changes outside governance files must be preserved.
+Missing decisions:
+- None for this pass.
+Working mode: `production`
+Success criteria / eval rubric:
+- Repo rules distinguish tool, collaborator-agent, ui-contract, and commerce-deferred work.
+- Task packet and eval contracts capture trust, data-scope, HITL, and read-only expectations.
+- Contract coverage protects the new guidance without inventing runtime enforcement.
+AI-specific review focus:
+- Unsupported policy claims
+- Security drift against existing data-handling guidance
+- Overreach beyond current repo maturity
+Harness components touched:
+- repo rules
+- task-packet contract
+- eval task catalog
+- repo contract tests
+Integration mode: `commerce-deferred`
+External dependency or registry:
+- Day 2 PDF recommendations only; no new runtime dependency introduced
+Trust level: `official`
+Data scope: `sanitized`
+HITL approval point:
+- Before any future side-effectful or sensitive external integration is added to the repo
+Write permission / read-only expectation:
+- Governance files are writable; external real-data integrations should default to read-only when unavoidable
+Transport/schema debugging plan:
+- Keep debugging guidance at the policy level; use existing lean-ctx workflow and documented contract tests for this pass
+Reasoning level: `ai:review`
+max initial files: `6`
+Overview/search plan:
+- Review existing governance assets first, then add Day 2 deltas only where the repo already has stable governance hooks
+Lean-ctx structure check (`ctx_tree`) scope:
+- repo root and `.ai/`
+Lean-ctx search plan (`ctx_search`):
+- interoperability, agentic, lean-ctx, security, review-gate terms
+Intended file reads (`ctx_read` / `ctx_multi_read`):
+- governance docs, task-packet template, eval tasks, contract tests
+Intended compressed shell commands (`ctx_shell` / `lean-ctx -c`):
+- targeted pytest for repo contract verification
+Raw/native fallback justification:
+- None expected

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,19 @@ Use `.ai/` for task-scoped packets and evaluation inputs/results when work is su
 - Review AI-generated code with equal or higher scrutiny than human-written code, especially around hallucinated dependencies, missing failure handling, and unsupported policy claims.
 - When an agent repeats a mistake, convert the lesson into a repo rule, template field, example, or test instead of relying on memory alone.
 
+## Interoperability Defaults
+
+- Choose tools or MCP-style integrations for bounded, schema-driven, fire-and-forget operations.
+- Choose collaborating agents or subagents for unbounded, ambiguous, multi-turn work that may pause for clarification.
+- For new integrations, search for an existing vetted tool, server, or skill first before inventing custom wrappers.
+- Prefer official, internal, or otherwise vetted registries over public community endpoints.
+- Do not use public or unverified tool servers as production dependencies.
+- Never place credentials in prompts or checked-in scripts; continue using environment variables or repo-approved secret configuration paths.
+- Default sensitive or real-data external access to non-production or sanitized environments; if real data access is unavoidable, require read-only scope when possible.
+- For side-effectful or sensitive external actions, require explicit human approval before side-effectful or sensitive external tool calls.
+- For UI-generating work, allow declarative or trusted-catalog UI contracts rather than arbitrary generated executable UI.
+- Defer AP2/UCP-style payment or procurement flows until the repo has an explicit autonomous transaction surface and dedicated guardrails.
+
 ## AI Context Budget
 
 - Start with `README.md`, `docs/USAGE.md`, and the active task packet if present.

--- a/PLANS.md
+++ b/PLANS.md
@@ -43,5 +43,10 @@
   - added explicit prototype vs production planning fields plus AI-specific review expectations for substantial work
   - normalized review templates with structured rubric and ship-gate metadata
   - intentionally deferred deeper runtime observability, traces, and model-routing work until the repo needs more than governance hardening
+- `2026-06-21`: aligned repo governance with the Day 2 interoperability guidance at the workflow layer:
+  - added repo-level defaults for tool vs collaborator-agent vs UI-contract decisions
+  - expanded `.ai` task-packet and eval-review fields with trust level, data scope, HITL, and read-only expectations
+  - added contract-test coverage so interoperability guardrails remain discoverable and hard to drift
+  - explicitly deferred AP2/UCP-style commerce flows until the repo has a real autonomous transaction surface
 
 ---

--- a/tests/test_repo_verify_contract.py
+++ b/tests/test_repo_verify_contract.py
@@ -63,6 +63,20 @@ def test_repo_governance_docs_define_lean_ctx_workflow_contract():
         "convert the lesson into a repo rule, template field, example, or test"
         in agents_guide
     )
+    assert "## Interoperability Defaults" in agents_guide
+    assert "bounded, schema-driven, fire-and-forget operations" in agents_guide
+    assert "unbounded, ambiguous, multi-turn work" in agents_guide
+    assert "search for an existing vetted tool, server, or skill first" in agents_guide
+    assert "official, internal, or otherwise vetted registries" in agents_guide
+    assert (
+        "public or unverified tool servers as production dependencies" in agents_guide
+    )
+    assert (
+        "require explicit human approval before side-effectful or sensitive external tool calls"
+        in agents_guide
+    )
+    assert "declarative or trusted-catalog UI contracts" in agents_guide
+    assert "Defer AP2/UCP-style payment or procurement flows" in agents_guide
 
     assert "## Lean-ctx Workflow" in agents_guide
     assert "start with `ctx_overview`" in agents_guide
@@ -90,11 +104,42 @@ def test_repo_governance_docs_define_lean_ctx_workflow_contract():
     assert '`ctx_shell` or `lean-ctx -c "<command>"`' in ai_readme
     assert "record the reason in the task packet" in ai_readme
     assert "`lean-ctx gain --deep`" in ai_readme
+    assert "## Interoperability Review Gate" in ai_readme
+    assert (
+        "integration mode: `tool | collaborator-agent | ui-contract | commerce-deferred`"
+        in ai_readme
+    )
+    assert (
+        "trust level: `official | internal | third-party-vetted | public-prototype-only`"
+        in ai_readme
+    )
+    assert (
+        "data scope: `synthetic | sanitized | real-nonprod | real-prod-readonly`"
+        in ai_readme
+    )
+    assert "read-only scope when possible" in ai_readme
+    assert "HITL approval point" in ai_readme
 
     assert "Working mode: `prototype | production`" in task_packet_template
     assert "Success criteria / eval rubric:" in task_packet_template
     assert "AI-specific review focus:" in task_packet_template
     assert "Harness components touched:" in task_packet_template
+    assert (
+        "Integration mode: `tool | collaborator-agent | ui-contract | commerce-deferred`"
+        in task_packet_template
+    )
+    assert "External dependency or registry:" in task_packet_template
+    assert (
+        "Trust level: `official | internal | third-party-vetted | public-prototype-only`"
+        in task_packet_template
+    )
+    assert (
+        "Data scope: `synthetic | sanitized | real-nonprod | real-prod-readonly`"
+        in task_packet_template
+    )
+    assert "HITL approval point:" in task_packet_template
+    assert "Write permission / read-only expectation:" in task_packet_template
+    assert "Transport/schema debugging plan:" in task_packet_template
 
     assert "Overview/search plan:" in task_packet_template
     assert "Lean-ctx structure check (`ctx_tree`) scope:" in task_packet_template
@@ -115,6 +160,15 @@ def test_repo_governance_docs_define_lean_ctx_workflow_contract():
     assert "Review lean-ctx routing guidance and fallback rules" in eval_tasks
     assert "Contract coverage protects the policy" in eval_tasks
     assert "- id: agentic-alignment-governance-review" in eval_tasks
+    assert "- id: day2-interoperability-governance-review" in eval_tasks
+    assert (
+        "Review Day 2 interoperability governance defaults and guardrails" in eval_tasks
+    )
+    assert (
+        "tool vs collaborator-agent vs ui-contract classification stays explicit"
+        in eval_tasks
+    )
+    assert "HITL, trust level, and real-data scope rules remain aligned" in eval_tasks
     assert (
         "unsupported policy claims, missing review gates, or doc/test drift"
         in eval_tasks

--- a/tests/test_repo_verify_contract.py
+++ b/tests/test_repo_verify_contract.py
@@ -8,6 +8,9 @@ AGENTS_GUIDE = ROOT / "AGENTS.md"
 AI_README = ROOT / ".ai" / "README.md"
 TASK_PACKET_TEMPLATE = ROOT / ".ai" / "task-packet-template.md"
 EVAL_TASKS = ROOT / ".ai" / "evals" / "tasks.yaml"
+DAY2_INTEROP_TASK_PACKET = (
+    ROOT / ".ai" / "tasks" / "2026-06-21-day2-interoperability-governance.md"
+)
 
 
 def _read(path: Path) -> str:
@@ -54,6 +57,7 @@ def test_repo_governance_docs_define_lean_ctx_workflow_contract():
     ai_readme = _read(AI_README)
     task_packet_template = _read(TASK_PACKET_TEMPLATE)
     eval_tasks = _read(EVAL_TASKS)
+    day2_task_packet = _read(DAY2_INTEROP_TASK_PACKET)
 
     assert "## Agentic Engineering Defaults" in agents_guide
     assert "working mode: `prototype` for exploration or `production`" in agents_guide
@@ -173,3 +177,11 @@ def test_repo_governance_docs_define_lean_ctx_workflow_contract():
         "unsupported policy claims, missing review gates, or doc/test drift"
         in eval_tasks
     )
+
+    assert "Working mode: `production`" in day2_task_packet
+    assert "Integration mode: `commerce-deferred`" in day2_task_packet
+    assert "Trust level: `official`" in day2_task_packet
+    assert "Data scope: `sanitized`" in day2_task_packet
+    assert "HITL approval point:" in day2_task_packet
+    assert "Write permission / read-only expectation:" in day2_task_packet
+    assert "Transport/schema debugging plan:" in day2_task_packet


### PR DESCRIPTION
## Summary
- add Day 2 interoperability governance defaults for tool vs collaborator-agent vs UI-contract decisions
- extend the `.ai` task-packet and eval contracts with trust level, data scope, HITL, and read-only expectations
- add repo contract-test coverage and a dated governance task packet for the Day 2 alignment pass

## Why
This keeps the repo’s governance layer aligned with the Day 2 interoperability guidance without pulling in runtime A2A, A2UI, AP2, or UCP implementation work.

## Impact
Contributors and coding agents now have explicit review gates for interoperability choices, while runtime product surfaces remain unchanged.

## Test Plan
- `pytest -q tests/test_repo_verify_contract.py`
- pre-commit hooks during `git commit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added “Interoperability Defaults” governance rules covering tool vs agent usage, credential handling, vetted tooling preferences, and default real-data access limits with explicit human approval for sensitive actions.
  * Introduced an “Interoperability Review Gate” checklist defining integration mode, trust level, data scope, HITL approval points, and UI-contract expectations.
  * Expanded task-packet guidance and Day 2 interoperability governance documentation, including deferred commerce/procurement guidance.

* **Tests**
  * Updated repo contract verification to enforce the new interoperability review-gate and task-packet/eval requirements, including the Day 2 governance template.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->