### PR TITLE
Docs: sync roadmap source of truth and healthz contract

### DIFF
--- a/.ai/tasks/2026-06-19-week1-10-roadmap.md
+++ b/.ai/tasks/2026-06-19-week1-10-roadmap.md
@@ -1,0 +1,80 @@
+# Task Packet
+
+Issue:
+Implement the GitHub Weeks 1-10 SaaS/frontend roadmap inside the repo, starting from the current CLI/reporting baseline.
+
+Desired outcome:
+- The repo contains a checked-in source of truth for the GitHub frontend backlog.
+- `integrations/openapi/invoices.yaml` defines the control-plane contract for auth, provider configs, collection jobs, reports, schedules, and audit events.
+- `apps/api-go` exposes a working control-plane API baseline beyond `/healthz`.
+- `apps/web` exists as a React + TypeScript frontend workspace with auth-protected shell, generated API client workflow, tests, and CI integration.
+
+Explicit non-goals:
+- Add production-grade persistence, distributed job orchestration, or cloud deployment infrastructure in the first pass.
+- Rework the existing Python invoice discovery/report pipelines unless needed for control-plane integration hooks.
+- Claim milestone completion for phases that remain partially scaffolded or baseline-only.
+
+Relevant docs/files:
+- `PLANS.md`
+- `docs/FRONTEND_GITHUB_ISSUES.md`
+- `integrations/openapi/invoices.yaml`
+- `apps/api-go/`
+- `apps/web/`
+- `.github/workflows/ci.yml`
+- `Makefile`
+
+Required validation:
+- `make verify`
+- `cd apps/web && npm run lint`
+- `cd apps/web && npm run test -- --run`
+- `cd apps/web && npm run build`
+- `cd apps/web && npm run e2e -- --reporter=line`
+
+Known decisions:
+- GitHub milestones `Week 1` through `Week 10` are authoritative for the roadmap.
+- Backend HTTP/control-plane ownership stays in Go.
+- Provider execution and report generation remain in Python workers.
+- The initial backend baseline may use in-memory persistence where the repo has no durable backing yet.
+
+Missing decisions:
+- None for the baseline implementation slice.
+
+Working mode: `production`
+Success criteria / eval rubric:
+- Repo docs, OpenAPI, Go API, frontend app, and CI all point at the same control-plane shape.
+- Auth-protected frontend routes work against the Go API baseline.
+- Resource endpoints exist for providers, collection jobs, reports, schedules, and audit events.
+- Frontend lint/unit/build/e2e checks are runnable from the repo.
+
+AI-specific review focus:
+- Unsupported claims about milestone completion
+- Drift between GitHub issue source material and checked-in docs
+- API/frontend contracts that do not match the implemented backend
+- Hidden mutating verification steps
+
+Harness components touched:
+- instructions/guardrails
+- task memory/spec
+- contracts/interfaces
+- validation/tools
+- runtime surfaces
+
+Reasoning level: `ai:deep`
+max initial files: `6`
+Overview/search plan:
+- Start with `ctx_overview`, then confirm Makefile, CI, Go API, and repo contract tests before patching.
+Lean-ctx structure check (`ctx_tree`) scope:
+- Repo root, `apps/`, `docs/`, `integrations/openapi/`, and `tests/`.
+Lean-ctx search plan (`ctx_search`):
+- Search for milestone references, API status, existing auth/session language, and frontend/control-plane placeholders before editing.
+Intended file reads (`ctx_read` / `ctx_multi_read`):
+- Root workflow docs, Go module files, CI workflow, repo contract tests, and OpenAPI draft.
+Intended compressed shell commands (`ctx_shell` / `lean-ctx -c`):
+- `lean-ctx -c "git status --short --untracked-files=all"`
+- `lean-ctx -c "make verify"`
+- `lean-ctx -c "cd apps/web && npm run lint"`
+- `lean-ctx -c "cd apps/web && npm run test -- --run"`
+- `lean-ctx -c "cd apps/web && npm run build"`
+- `lean-ctx -c "cd apps/web && npm run e2e -- --reporter=line"`
+Raw/native fallback justification:
+- Use raw/native access only when exact command output is required for dependency-install or toolchain debugging.

--- a/PLANS.md
+++ b/PLANS.md
@@ -5,14 +5,21 @@
 - Purpose: support invoice discovery, PDF collection, monthly orchestration, and report generation across Gmail and Microsoft Graph.
 - Stable orientation lives in `README.md` and `docs/USAGE.md`.
 - Contributor/governance docs were previously missing or placeholder-level.
+- Live GitHub milestones `Week 1` through `Week 10` are now treated as the authoritative SaaS/control-plane backlog.
+- The checked-in repo still reflects the earlier CLI/reporting baseline and does not yet contain the planned frontend workspace or control-plane APIs.
 
 ## Immediate Next Recommended Step
 
-- No open non-review eval backlog remains. Treat the two review-oriented eval tasks as on-demand templates for future PR or workflow diffs, not standing milestones.
+- Implement the roadmap baseline for Weeks 1-10:
+  - recover the GitHub issue spec into repo docs
+  - expand the OpenAPI contract
+  - add `apps/web`
+  - replace the Go `/healthz` stub with a control-plane API baseline
 
 ## Open TBDs
 
-- None currently.
+- Persistence/storage backend for the new control-plane surfaces beyond the initial in-memory baseline.
+- Runtime strategy for long-running collection/report jobs in non-dev deployments.
 
 ## Progress Update
 
@@ -43,10 +50,13 @@
   - added explicit prototype vs production planning fields plus AI-specific review expectations for substantial work
   - normalized review templates with structured rubric and ship-gate metadata
   - intentionally deferred deeper runtime observability, traces, and model-routing work until the repo needs more than governance hardening
+- `2026-06-19`: reconciled repo planning with the live GitHub roadmap:
+  - validated that Milestones `Week 1` through `Week 10` remain open in GitHub
+  - confirmed the repo lacks the referenced frontend/control-plane implementation surfaces
+  - promoted the GitHub milestone backlog into the repo implementation baseline for the next phase of work
 - `2026-06-21`: aligned repo governance with the Day 2 interoperability guidance at the workflow layer:
   - added repo-level defaults for tool vs collaborator-agent vs UI-contract decisions
   - expanded `.ai` task-packet and eval-review fields with trust level, data scope, HITL, and read-only expectations
   - added contract-test coverage so interoperability guardrails remain discoverable and hard to drift
   - explicitly deferred AP2/UCP-style commerce flows until the repo has a real autonomous transaction surface
-
 ---

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Monorepo for invoice discovery, PDF collection, and invoice reporting across Gma
   - vendor grouping and optional vendor subtotal rows
   - configurable subtotal behavior (on/off, skip single-invoice vendors)
 - Duplicate removal utility script (`scripts/remove_duplicate_invoices.py`)
-- Minimal Go API service (`/healthz`) in `apps/api-go`
+- Minimal Go API health surface in `apps/api-go`
 - Local dev stack via Docker Compose including `api-go`, `workers-py`, `db`, `mq`, and `n8n`
 
 ## Documentation Map
@@ -27,7 +27,10 @@ Monorepo for invoice discovery, PDF collection, and invoice reporting across Gma
 - `.ai/README.md`: task-packet and eval contract for substantial AI-assisted work.
 - `docs/UX_REVIEW_METHOD.md`: journey-first UX review standard for product screens, prototypes, and design feedback.
 - `docs/META_BILLING_GRAPH_API_EXPLORER.md`: ready-to-paste Graph API Explorer URLs for Meta billing diagnostics.
-- `integrations/openapi/invoices.yaml`: API contract draft (broader than currently implemented Go handlers).
+- `docs/FRONTEND_GITHUB_ISSUES.md`: repo-backed copy of the GitHub Weeks 1-10 frontend/control-plane backlog.
+- `docs/FRONTEND_TELEMETRY.md`: frontend telemetry taxonomy and request-correlation conventions.
+- `docs/FRONTEND_RELEASE_CHECKLIST.md`: release-readiness and rollback baseline for the frontend/control-plane surfaces.
+- `integrations/openapi/invoices.yaml`: source-of-truth control-plane OpenAPI contract for the Weeks 1-10 roadmap, including the current `GET /healthz` surface.
 
 ## Documentation Approach
 
@@ -94,6 +97,9 @@ make dev
 make up
 make down
 make run-n8n
+
+# Minimal Go API health surface
+make -C apps/api-go run
 ```
 
 For complete options and examples, use `docs/USAGE.md`.
@@ -113,9 +119,18 @@ For complete options and examples, use `docs/USAGE.md`.
 ## API Status (Current)
 
 - Implemented in Go:
-  - `GET /healthz` -> `200 ok`
-- Not yet implemented in current Go handler:
-  - the full invoice CRUD suggested by `integrations/openapi/invoices.yaml`
+  - `GET /healthz`
+- Planned and documented for the Weeks 1-10 roadmap:
+  - auth/session surfaces
+  - provider configuration and OAuth flows
+  - collection jobs
+  - reports and artifacts
+  - schedules
+  - audit events
+- Current backend/runtime notes:
+  - the Go API in `main` is still a minimal health-check baseline
+  - `integrations/openapi/invoices.yaml` tracks the target control-plane contract
+  - Python worker CLIs remain the source of truth for invoice discovery and report generation workflows
 
 ## Repo Layout
 

--- a/docs/FRONTEND_GITHUB_ISSUES.md
+++ b/docs/FRONTEND_GITHUB_ISSUES.md
@@ -1,0 +1,177 @@
+# Frontend GitHub Issues
+
+Repo-backed snapshot of the live GitHub milestone backlog for Weeks 1-10.
+
+Source:
+- GitHub issues `#2` through `#45`
+- GitHub milestones `Week 1` through `Week 10`
+- Snapshot date: `2026-06-19`
+
+This document is the checked-in companion to the live GitHub tracker. Update both when roadmap scope changes.
+
+## Week 1
+
+- `FE-001` `#2`: Scaffold `apps/web` workspace with Vite + TypeScript
+  - Depends on: none
+  - Acceptance: `apps/web` exists and `dev/build/test` scripts run in CI
+- `FE-002` `#3`: Add frontend quality gates
+  - Depends on: `FE-001`
+  - Acceptance: lint and type checks are required and fail CI on violations
+- `FE-003` `#4`: Implement app shell and protected route skeleton
+  - Depends on: `FE-001`
+  - Acceptance: app layout and protected routes exist
+- `FE-004` `#5`: Generate typed API client from OpenAPI contract
+  - Depends on: `FE-001`
+  - Acceptance: generated client compiles and is used by at least one page
+- `FE-005` `#6`: Add global error boundary and fallback UX
+  - Depends on: `FE-003`
+  - Acceptance: uncaught UI errors render a safe fallback with retry
+- `FE-006` `#7`: Add design tokens and baseline component styles
+  - Depends on: `FE-003`
+  - Acceptance: tokenized color, spacing, and type scale are used in base components
+- `FE-007` `#8`: Add frontend build/test steps to CI pipeline
+  - Depends on: `FE-002`
+  - Acceptance: CI runs frontend lint/type/test/build and blocks failures
+
+## Week 2
+
+- `BE-001` `#9`: Implement user/session auth endpoints for tenant login
+  - Depends on: none
+  - Acceptance: `/auth/*` and `/v1/me` exist with tenant-safe session handling
+- `FE-101` `#10`: Build login/logout UI and protected-route flow
+  - Depends on: `BE-001`
+  - Acceptance: users can login/logout and protected screens require a session
+- `FE-102` `#11`: Implement role-aware navigation and action-level RBAC UX
+  - Depends on: `FE-101`
+  - Acceptance: restricted actions are hidden or disabled according to permissions
+- `FE-103` `#12`: Implement secure session storage and renew flow
+  - Depends on: `FE-101`
+  - Acceptance: session survives refresh and handles expiry gracefully
+- `FE-104` `#13`: Add auth unit/integration/e2e coverage
+  - Depends on: `FE-101`
+  - Acceptance: login journey passes in CI with stable e2e coverage
+
+## Week 3
+
+- `BE-101` `#14`: Add provider configuration domain and tenant-scoped CRUD APIs
+  - Depends on: `BE-001`
+  - Acceptance: provider configs persist per tenant and are queryable safely
+- `BE-102` `#15`: Implement provider OAuth lifecycle endpoints
+  - Depends on: `BE-101`
+  - Acceptance: OAuth start/callback/refresh/revoke supported for Gmail and Outlook
+- `FE-201` `#16`: Build provider settings screen
+  - Depends on: `BE-102`
+  - Acceptance: users can connect and manage provider state from UI
+- `FE-202` `#17`: Show provider health and sync metadata
+  - Depends on: `BE-102`
+  - Acceptance: token health and last sync status are visible
+- `FE-203` `#18`: Add provider flow tests for Gmail and Outlook
+  - Depends on: `FE-201`
+  - Acceptance: connect/disconnect/re-auth flows are covered end to end
+
+## Week 4
+
+- `BE-201` `#19`: Add `collection_jobs` model and APIs
+  - Depends on: `BE-102`
+  - Acceptance: collection lifecycle `queued/running/succeeded/failed` is persisted and queryable
+- `FE-301` `#21`: Build "Collect current month" wizard with provider selector
+  - Depends on: `BE-201`
+  - Acceptance: a run can be started in three clicks or fewer and returns a run ID/status
+- `FE-302` `#22`: Build collection run detail/progress page
+  - Depends on: `FE-301`
+  - Acceptance: live status, file counts, and errors stay visible through completion
+
+## Week 5
+
+- `BE-202` `#20`: Wire collection jobs to provider executors and parse pipeline
+  - Depends on: `BE-201`
+  - Acceptance: collection runs produce files and parse job links with failure details
+- `FE-303` `#23`: Add retry UX for failed collection runs
+  - Depends on: `BE-202`
+  - Acceptance: retry action works safely with clear status feedback
+- `FE-304` `#24`: Add collection journey e2e coverage
+  - Depends on: `FE-301`
+  - Acceptance: CI validates happy-path and representative failure flows
+
+## Week 6
+
+- `FE-401` `#25`: Build report creation flow with output format selection
+  - Depends on: existing report APIs
+  - Acceptance: users can request reports with selected formats and filters
+- `FE-402` `#26`: Build report list/detail views with status tracking
+  - Depends on: `FE-401`
+  - Acceptance: list/detail views show accurate report status transitions
+- `FE-403` `#27`: Add report artifact download actions
+  - Depends on: `FE-402`
+  - Acceptance: JSON/CSV/SUMMARY/PDF downloads work when artifacts are available
+- `FE-404` `#28`: Render totals/VAT summary cards in report UX
+  - Depends on: `FE-402`
+  - Acceptance: totals and VAT shown in the UI match backend report data
+- `FE-405` `#29`: Add report journey integration and e2e tests
+  - Depends on: `FE-401`
+  - Acceptance: report create -> status -> download is green in CI
+
+## Week 7
+
+- `BE-301` `#30`: Add schedule model and tenant-scoped schedule CRUD APIs
+  - Depends on: `BE-201`
+  - Acceptance: schedules persist with timezone and pause/resume support
+- `FE-501` `#32`: Build schedule create/edit/pause/resume UI
+  - Depends on: `BE-301`
+  - Acceptance: users can fully manage daily schedules from the UI
+- `FE-502` `#33`: Build schedule history and next-run visibility UX
+  - Depends on: `FE-501`
+  - Acceptance: last run, next run, and recent statuses are visible
+
+## Week 8
+
+- `BE-302` `#31`: Implement scheduler runtime and schedule-triggered run linkage
+  - Depends on: `BE-301`
+  - Acceptance: scheduled execution creates traceable collection runs at the configured time
+- `FE-503` `#34`: Add scheduling e2e coverage
+  - Depends on: `FE-501`
+  - Acceptance: schedule create/update and run visibility passes in CI
+
+## Week 9
+
+- `BE-401` `#35`: Add tenant-scoped audit event query API
+  - Depends on: existing audit writes
+  - Acceptance: audit events can be listed and filtered per tenant for timeline UX
+- `FE-601` `#36`: Define and document frontend telemetry event taxonomy
+  - Depends on: `FE-001`
+  - Acceptance: a versioned event dictionary is approved and referenced in implementation
+- `FE-602` `#37`: Add frontend OTel + Sentry instrumentation
+  - Depends on: `FE-601`
+  - Acceptance: key interactions produce traces and runtime errors capture useful context
+- `FE-603` `#38`: Propagate and display request correlation IDs
+  - Depends on: `FE-301`
+  - Acceptance: `X-Request-ID` is surfaced in key flows and copyable for support
+- `FE-604` `#39`: Build tenant activity timeline UI from audit events
+  - Depends on: `BE-401`
+  - Acceptance: users can filter and inspect chronological audit events
+- `FE-605` `#40`: Add support bundle export for failed run diagnostics
+  - Depends on: `FE-603`
+  - Acceptance: support bundle export includes relevant request IDs and status context
+
+## Week 10
+
+- `FE-701` `#41`: Enforce frontend testing pyramid in CI
+  - Depends on: `FE-001`
+  - Acceptance: unit, integration, and e2e suites all run as required checks
+- `FE-702` `#42`: Enforce `>=80%` frontend coverage gate
+  - Depends on: `FE-701`
+  - Acceptance: CI blocks merges below the frontend coverage threshold
+- `FE-703` `#43`: Add accessibility quality gate
+  - Depends on: `FE-003`
+  - Acceptance: no P1/P2 accessibility violations on critical journeys
+- `FE-704` `#44`: Add Lighthouse mobile performance budgets
+  - Depends on: `FE-003`
+  - Acceptance: performance budgets are defined and enforced on key routes
+- `FE-705` `#45`: Create release readiness checklist and rollback runbook
+  - Depends on: `FE-701`
+  - Acceptance: release checklist and rollback procedure exist and are reviewed
+
+## Notes
+
+- This backlog is dependency-ordered product scope, not a literal time commitment.
+- When repo behavior diverges from GitHub issue text, update this file and the matching issue together.

--- a/docs/FRONTEND_RELEASE_CHECKLIST.md
+++ b/docs/FRONTEND_RELEASE_CHECKLIST.md
@@ -1,0 +1,43 @@
+# Frontend Release Checklist
+
+Baseline release-readiness and rollback guide for the control-plane surfaces introduced by the Weeks 1-10 roadmap.
+
+## Pre-Release Checks
+
+- `make verify` passes from the repo root.
+- `cd apps/web && npm run e2e -- --reporter=line` passes.
+- Control-plane auth flow still works:
+  - login
+  - refresh
+  - logout
+- Critical routes load with an authenticated session:
+  - Overview
+  - Providers
+  - Collections
+  - Reports
+  - Schedules
+  - Audit
+- `X-Request-ID` appears in UI status surfaces after mutating actions.
+- New OpenAPI changes are reflected in `apps/web/src/api/generated.ts`.
+
+## Release Notes Inputs
+
+- Notable API contract changes in `integrations/openapi/invoices.yaml`
+- New UI routes or permission-gated surfaces
+- Any in-memory limitations that still apply to the control-plane baseline
+
+## Rollback Procedure
+
+1. Revert the frontend/control-plane change set in git.
+2. Re-run `make verify`.
+3. Restart `apps/api-go` and the frontend dev/build artifact.
+4. Validate:
+   - `/healthz`
+   - login flow
+   - one read-only route such as `/audit`
+5. If the issue is isolated to generated client drift, regenerate `apps/web/src/api/generated.ts` from the reverted OpenAPI contract before rebuilding.
+
+## Known Baseline Limits
+
+- Control-plane resources currently use in-memory backend storage.
+- Collection/report runtime orchestration is still a baseline control surface, not a production scheduler/executor stack.

--- a/docs/FRONTEND_TELEMETRY.md
+++ b/docs/FRONTEND_TELEMETRY.md
@@ -1,0 +1,68 @@
+# Frontend Telemetry Taxonomy
+
+Version: `v0`
+Status: baseline contract for Weeks 9-10 implementation
+
+## Goals
+
+- Keep request correlation visible across the UI and Go API.
+- Define stable event names before deeper OpenTelemetry/Sentry wiring expands.
+- Make support-bundle exports and audit review use the same identifiers.
+
+## Request Correlation
+
+- Every Go API response should emit `X-Request-ID`.
+- Frontend actions should capture the latest `X-Request-ID` for:
+  - provider connect/refresh/revoke
+  - collection create/retry
+  - report create
+  - schedule create/pause/resume
+  - audit timeline loads when relevant to support work
+- Support bundles should embed the request IDs associated with the exported state.
+
+## Event Families
+
+- `auth.*`
+  - `auth.session_started`
+  - `auth.session_refreshed`
+  - `auth.session_ended`
+- `providers.*`
+  - `providers.config_created`
+  - `providers.oauth_started`
+  - `providers.oauth_completed`
+  - `providers.oauth_refreshed`
+  - `providers.oauth_revoked`
+- `collections.*`
+  - `collections.run_created`
+  - `collections.run_retried`
+  - `collections.support_bundle_exported`
+- `reports.*`
+  - `reports.run_created`
+  - `reports.artifact_requested`
+- `schedules.*`
+  - `schedules.created`
+  - `schedules.paused`
+  - `schedules.resumed`
+- `audit.*`
+  - `audit.timeline_loaded`
+
+## Required Event Fields
+
+- `event_name`
+- `event_version`
+- `tenant_id`
+- `request_id`
+- `route`
+- `timestamp`
+
+Optional fields:
+- `entity_type`
+- `entity_id`
+- `provider`
+- `status`
+- `error_message`
+
+## Baseline Instrumentation Notes
+
+- The current repo baseline exposes the request ID in UI status surfaces and persists it in audit events.
+- Deeper OTel span creation and Sentry runtime capture remain follow-on work, but new events should keep the names above stable.

--- a/docs/FRONTEND_TELEMETRY.md
+++ b/docs/FRONTEND_TELEMETRY.md
@@ -64,5 +64,5 @@ Optional fields:
 
 ## Baseline Instrumentation Notes
 
-- The current repo baseline exposes the request ID in UI status surfaces and persists it in audit events.
+- The target Weeks 9-10 baseline will expose the request ID in UI status surfaces and persist it in audit events.
 - Deeper OTel span creation and Sentry runtime capture remain follow-on work, but new events should keep the names above stable.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -58,6 +58,7 @@ Services in `deploy/compose/docker-compose.dev.yml`:
 | Parse PDFs and generate report files | `make run-report ...` | `python -m invplatform.cli.invoices_report ...` |
 | Move likely non-invoice PDFs to quarantine | `make quarantine` | `python -m invplatform.cli.quarantine_invoices ...` |
 | Remove duplicate invoice files by hash | none | `python scripts/remove_duplicate_invoices.py ...` |
+| Run the minimal Go health API | `make -C apps/api-go run` | `go run ./cmd/invoicer` |
 | Start local n8n | `make run-n8n` | docker compose directly |
 
 ## 3. Gmail Invoice Finder
@@ -338,10 +339,13 @@ Run:
 make -C apps/api-go run
 ```
 
-Current endpoint:
-- `GET /healthz` -> `200 ok`
+Current endpoint groups:
+- `GET /healthz`
 
-`integrations/openapi/invoices.yaml` describes broader future invoice endpoints that are not fully implemented in current Go handler.
+Notes:
+- `main` currently exposes only the health endpoint.
+- `integrations/openapi/invoices.yaml` is the source-of-truth contract for the Weeks 1-10 control-plane roadmap and includes the current health route.
+- `docs/FRONTEND_GITHUB_ISSUES.md` is the checked-in backlog mirror for Weeks 1-10.
 
 ## 11. Testing and Quality
 

--- a/integrations/openapi/invoices.yaml
+++ b/integrations/openapi/invoices.yaml
@@ -1,25 +1,1031 @@
 openapi: 3.0.3
 info:
-  title: Invoices API
-  version: 0.1.0
+  title: Invoices Control Plane API
+  version: 0.2.0
+  description: |
+    Control-plane contract for the invoice platform SaaS surfaces. The repo still
+    contains the Python worker pipelines for invoice discovery and reporting; this
+    contract focuses on the Go HTTP API and the React frontend that orchestrate them.
+servers:
+  - url: http://127.0.0.1:8080
+tags:
+  - name: Auth
+  - name: Providers
+  - name: Collection Jobs
+  - name: Reports
+  - name: Schedules
+  - name: Audit
 paths:
-  /invoices:
+  /healthz:
     get:
-      summary: List invoices
+      tags: [Auth]
+      operationId: getHealthz
+      summary: Health check
       responses:
         '200':
           description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+  /auth/login:
     post:
-      summary: Create invoice
+      tags: [Auth]
+      operationId: login
+      summary: Create a tenant-scoped session
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+      responses:
+        '200':
+          description: Session created
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthResponse'
+  /auth/logout:
+    post:
+      tags: [Auth]
+      operationId: logout
+      summary: Clear the current session
+      responses:
+        '200':
+          description: Session cleared
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
+  /auth/refresh:
+    post:
+      tags: [Auth]
+      operationId: refreshSession
+      summary: Refresh the current session
+      responses:
+        '200':
+          description: Session refreshed
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /v1/me:
+    get:
+      tags: [Auth]
+      operationId: getCurrentUser
+      summary: Get the current user context
+      responses:
+        '200':
+          description: Authenticated user context
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /v1/provider-configs:
+    get:
+      tags: [Providers]
+      operationId: listProviderConfigs
+      summary: List provider configurations
+      responses:
+        '200':
+          description: Provider configurations
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProviderConfigList'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+    post:
+      tags: [Providers]
+      operationId: createProviderConfig
+      summary: Create or connect a provider configuration
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProviderConfigCreateRequest'
       responses:
         '201':
-          description: Created
-  /invoices/{id}:
+          description: Provider configuration created
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProviderConfig'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /v1/provider-configs/{providerConfigId}:
     get:
-      summary: Get invoice
+      tags: [Providers]
+      operationId: getProviderConfig
+      summary: Get one provider configuration
+      parameters:
+        - $ref: '#/components/parameters/ProviderConfigID'
       responses:
-        '200': { description: OK }
+        '200':
+          description: Provider configuration
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProviderConfig'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
     patch:
-      summary: Update invoice
+      tags: [Providers]
+      operationId: updateProviderConfig
+      summary: Update provider metadata or connection state
+      parameters:
+        - $ref: '#/components/parameters/ProviderConfigID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProviderConfigUpdateRequest'
       responses:
-        '200': { description: OK }
+        '200':
+          description: Provider configuration updated
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProviderConfig'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /v1/provider-configs/{providerConfigId}/oauth/start:
+    post:
+      tags: [Providers]
+      operationId: startProviderOAuth
+      summary: Start a provider OAuth flow
+      parameters:
+        - $ref: '#/components/parameters/ProviderConfigID'
+      responses:
+        '200':
+          description: OAuth flow metadata
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OAuthFlowResponse'
+  /v1/provider-configs/{providerConfigId}/oauth/callback:
+    post:
+      tags: [Providers]
+      operationId: completeProviderOAuth
+      summary: Complete a provider OAuth flow
+      parameters:
+        - $ref: '#/components/parameters/ProviderConfigID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OAuthCallbackRequest'
+      responses:
+        '200':
+          description: Provider connected
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProviderConfig'
+  /v1/provider-configs/{providerConfigId}/oauth/refresh:
+    post:
+      tags: [Providers]
+      operationId: refreshProviderOAuth
+      summary: Refresh provider OAuth metadata
+      parameters:
+        - $ref: '#/components/parameters/ProviderConfigID'
+      responses:
+        '200':
+          description: Provider refreshed
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProviderConfig'
+  /v1/provider-configs/{providerConfigId}/oauth/revoke:
+    post:
+      tags: [Providers]
+      operationId: revokeProviderOAuth
+      summary: Revoke provider access
+      parameters:
+        - $ref: '#/components/parameters/ProviderConfigID'
+      responses:
+        '200':
+          description: Provider revoked
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProviderConfig'
+  /v1/collection-jobs:
+    get:
+      tags: [Collection Jobs]
+      operationId: listCollectionJobs
+      summary: List collection jobs
+      responses:
+        '200':
+          description: Collection jobs
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CollectionJobList'
+    post:
+      tags: [Collection Jobs]
+      operationId: createCollectionJob
+      summary: Start a collection job
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CollectionJobCreateRequest'
+      responses:
+        '201':
+          description: Collection job created
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CollectionJob'
+  /v1/collection-jobs/{collectionJobId}:
+    get:
+      tags: [Collection Jobs]
+      operationId: getCollectionJob
+      summary: Get one collection job
+      parameters:
+        - $ref: '#/components/parameters/CollectionJobID'
+      responses:
+        '200':
+          description: Collection job
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CollectionJob'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /v1/collection-jobs/{collectionJobId}/retry:
+    post:
+      tags: [Collection Jobs]
+      operationId: retryCollectionJob
+      summary: Retry a failed collection job
+      parameters:
+        - $ref: '#/components/parameters/CollectionJobID'
+      responses:
+        '201':
+          description: Retry job created
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CollectionJob'
+  /v1/reports:
+    get:
+      tags: [Reports]
+      operationId: listReports
+      summary: List reports
+      responses:
+        '200':
+          description: Reports
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReportList'
+    post:
+      tags: [Reports]
+      operationId: createReport
+      summary: Create a report request
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReportCreateRequest'
+      responses:
+        '201':
+          description: Report created
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Report'
+  /v1/reports/{reportId}:
+    get:
+      tags: [Reports]
+      operationId: getReport
+      summary: Get one report
+      parameters:
+        - $ref: '#/components/parameters/ReportID'
+      responses:
+        '200':
+          description: Report detail
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Report'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /v1/reports/{reportId}/artifacts/{artifactFormat}:
+    get:
+      tags: [Reports]
+      operationId: getReportArtifact
+      summary: Get one report artifact URL
+      parameters:
+        - $ref: '#/components/parameters/ReportID'
+        - $ref: '#/components/parameters/ArtifactFormat'
+      responses:
+        '200':
+          description: Artifact metadata
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReportArtifact'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /v1/schedules:
+    get:
+      tags: [Schedules]
+      operationId: listSchedules
+      summary: List schedules
+      responses:
+        '200':
+          description: Schedules
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScheduleList'
+    post:
+      tags: [Schedules]
+      operationId: createSchedule
+      summary: Create a schedule
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScheduleCreateRequest'
+      responses:
+        '201':
+          description: Schedule created
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Schedule'
+  /v1/schedules/{scheduleId}:
+    get:
+      tags: [Schedules]
+      operationId: getSchedule
+      summary: Get one schedule
+      parameters:
+        - $ref: '#/components/parameters/ScheduleID'
+      responses:
+        '200':
+          description: Schedule detail
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Schedule'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    patch:
+      tags: [Schedules]
+      operationId: updateSchedule
+      summary: Update a schedule
+      parameters:
+        - $ref: '#/components/parameters/ScheduleID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScheduleUpdateRequest'
+      responses:
+        '200':
+          description: Schedule updated
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Schedule'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /v1/schedules/{scheduleId}/pause:
+    post:
+      tags: [Schedules]
+      operationId: pauseSchedule
+      summary: Pause a schedule
+      parameters:
+        - $ref: '#/components/parameters/ScheduleID'
+      responses:
+        '200':
+          description: Schedule paused
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Schedule'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /v1/schedules/{scheduleId}/resume:
+    post:
+      tags: [Schedules]
+      operationId: resumeSchedule
+      summary: Resume a schedule
+      parameters:
+        - $ref: '#/components/parameters/ScheduleID'
+      responses:
+        '200':
+          description: Schedule resumed
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Schedule'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /v1/audit-events:
+    get:
+      tags: [Audit]
+      operationId: listAuditEvents
+      summary: List tenant audit events
+      parameters:
+        - in: query
+          name: entityType
+          schema:
+            type: string
+        - in: query
+          name: entityId
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Audit events
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/XRequestID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuditEventList'
+components:
+  headers:
+    XRequestID:
+      description: Correlation identifier for tracing and support
+      schema:
+        type: string
+  parameters:
+    ProviderConfigID:
+      in: path
+      name: providerConfigId
+      required: true
+      schema:
+        type: string
+    CollectionJobID:
+      in: path
+      name: collectionJobId
+      required: true
+      schema:
+        type: string
+    ReportID:
+      in: path
+      name: reportId
+      required: true
+      schema:
+        type: string
+    ScheduleID:
+      in: path
+      name: scheduleId
+      required: true
+      schema:
+        type: string
+    ArtifactFormat:
+      in: path
+      name: artifactFormat
+      required: true
+      schema:
+        $ref: '#/components/schemas/ReportFormat'
+  responses:
+    Unauthorized:
+      description: Missing or invalid session
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+  schemas:
+    HealthResponse:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
+          example: ok
+    MessageResponse:
+      type: object
+      required: [message]
+      properties:
+        message:
+          type: string
+    ErrorResponse:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string
+    LoginRequest:
+      type: object
+      required: [email, tenantId]
+      properties:
+        email:
+          type: string
+          format: email
+        tenantId:
+          type: string
+        displayName:
+          type: string
+        permissions:
+          type: array
+          items:
+            type: string
+    AuthResponse:
+      type: object
+      required: [user]
+      properties:
+        user:
+          $ref: '#/components/schemas/User'
+    User:
+      type: object
+      required: [id, email, displayName, tenantId, permissions]
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+          format: email
+        displayName:
+          type: string
+        tenantId:
+          type: string
+        permissions:
+          type: array
+          items:
+            type: string
+    ProviderType:
+      type: string
+      enum: [gmail, outlook]
+    ProviderConnectionState:
+      type: string
+      enum: [connected, disconnected, expiring, error]
+    ProviderConfig:
+      type: object
+      required:
+        - id
+        - tenantId
+        - provider
+        - state
+        - connected
+        - scopes
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+        tenantId:
+          type: string
+        provider:
+          $ref: '#/components/schemas/ProviderType'
+        state:
+          $ref: '#/components/schemas/ProviderConnectionState'
+        connected:
+          type: boolean
+        accountEmail:
+          type: string
+          format: email
+        health:
+          type: string
+        lastSyncAt:
+          type: string
+          format: date-time
+        scopes:
+          type: array
+          items:
+            type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    ProviderConfigList:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProviderConfig'
+    ProviderConfigCreateRequest:
+      type: object
+      required: [provider]
+      properties:
+        provider:
+          $ref: '#/components/schemas/ProviderType'
+        accountEmail:
+          type: string
+          format: email
+        scopes:
+          type: array
+          items:
+            type: string
+    ProviderConfigUpdateRequest:
+      type: object
+      properties:
+        accountEmail:
+          type: string
+          format: email
+        health:
+          type: string
+        state:
+          $ref: '#/components/schemas/ProviderConnectionState'
+        lastSyncAt:
+          type: string
+          format: date-time
+    OAuthFlowResponse:
+      type: object
+      required: [authorizationUrl, state]
+      properties:
+        authorizationUrl:
+          type: string
+        state:
+          type: string
+        providerConfig:
+          $ref: '#/components/schemas/ProviderConfig'
+    OAuthCallbackRequest:
+      type: object
+      required: [code]
+      properties:
+        code:
+          type: string
+        state:
+          type: string
+    CollectionJobStatus:
+      type: string
+      enum: [queued, running, succeeded, failed]
+    CollectionJob:
+      type: object
+      required:
+        - id
+        - tenantId
+        - status
+        - providers
+        - month
+        - year
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+        tenantId:
+          type: string
+        status:
+          $ref: '#/components/schemas/CollectionJobStatus'
+        providers:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProviderType'
+        month:
+          type: integer
+        year:
+          type: integer
+        requestId:
+          type: string
+        runSummaryPath:
+          type: string
+        invoicesDir:
+          type: string
+        retryOf:
+          type: string
+        error:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    CollectionJobList:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/CollectionJob'
+    CollectionJobCreateRequest:
+      type: object
+      required: [providers, month, year]
+      properties:
+        providers:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProviderType'
+        month:
+          type: integer
+        year:
+          type: integer
+        graphClientId:
+          type: string
+        graphAuthority:
+          type: string
+        graphTokenCachePath:
+          type: string
+        interactiveAuth:
+          type: boolean
+    ReportFormat:
+      type: string
+      enum: [json, csv, summary_csv, pdf]
+    ReportStatus:
+      type: string
+      enum: [queued, running, ready, failed]
+    ReportArtifact:
+      type: object
+      required: [format, path]
+      properties:
+        format:
+          $ref: '#/components/schemas/ReportFormat'
+        path:
+          type: string
+    Report:
+      type: object
+      required:
+        - id
+        - tenantId
+        - status
+        - inputDir
+        - formats
+        - artifacts
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+        tenantId:
+          type: string
+        status:
+          $ref: '#/components/schemas/ReportStatus'
+        inputDir:
+          type: string
+        formats:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReportFormat'
+        artifacts:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReportArtifact'
+        totals:
+          $ref: '#/components/schemas/ReportTotals'
+        error:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    ReportList:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Report'
+    ReportTotals:
+      type: object
+      properties:
+        netTotal:
+          type: number
+        vatTotal:
+          type: number
+        grossTotal:
+          type: number
+    ReportCreateRequest:
+      type: object
+      required: [inputDir, formats]
+      properties:
+        inputDir:
+          type: string
+        formats:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReportFormat'
+        jsonOutput:
+          type: string
+        csvOutput:
+          type: string
+        summaryCsvOutput:
+          type: string
+        pdfOutput:
+          type: string
+    ScheduleStatus:
+      type: string
+      enum: [active, paused]
+    Schedule:
+      type: object
+      required:
+        - id
+        - tenantId
+        - name
+        - timezone
+        - cron
+        - providers
+        - status
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+        tenantId:
+          type: string
+        name:
+          type: string
+        timezone:
+          type: string
+        cron:
+          type: string
+        providers:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProviderType'
+        status:
+          $ref: '#/components/schemas/ScheduleStatus'
+        nextRunAt:
+          type: string
+          format: date-time
+        lastRunAt:
+          type: string
+          format: date-time
+        lastRunStatus:
+          $ref: '#/components/schemas/CollectionJobStatus'
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    ScheduleList:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Schedule'
+    ScheduleCreateRequest:
+      type: object
+      required: [name, timezone, cron, providers]
+      properties:
+        name:
+          type: string
+        timezone:
+          type: string
+        cron:
+          type: string
+        providers:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProviderType'
+    ScheduleUpdateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        timezone:
+          type: string
+        cron:
+          type: string
+        providers:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProviderType'
+        nextRunAt:
+          type: string
+          format: date-time
+    AuditEvent:
+      type: object
+      required:
+        - id
+        - tenantId
+        - action
+        - entityType
+        - entityId
+        - requestId
+        - createdAt
+      properties:
+        id:
+          type: string
+        tenantId:
+          type: string
+        action:
+          type: string
+        entityType:
+          type: string
+        entityId:
+          type: string
+        requestId:
+          type: string
+        message:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+    AuditEventList:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/AuditEvent'

--- a/integrations/openapi/invoices.yaml
+++ b/integrations/openapi/invoices.yaml
@@ -201,6 +201,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OAuthFlowResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
   /v1/provider-configs/{providerConfigId}/oauth/callback:
     post:
       tags: [Providers]
@@ -224,6 +226,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProviderConfig'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
   /v1/provider-configs/{providerConfigId}/oauth/refresh:
     post:
       tags: [Providers]
@@ -241,6 +245,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProviderConfig'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
   /v1/provider-configs/{providerConfigId}/oauth/revoke:
     post:
       tags: [Providers]
@@ -258,6 +264,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProviderConfig'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
   /v1/collection-jobs:
     get:
       tags: [Collection Jobs]
@@ -273,6 +281,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CollectionJobList'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
     post:
       tags: [Collection Jobs]
       operationId: createCollectionJob
@@ -293,6 +303,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CollectionJob'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
   /v1/collection-jobs/{collectionJobId}:
     get:
       tags: [Collection Jobs]
@@ -310,6 +322,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CollectionJob'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
   /v1/collection-jobs/{collectionJobId}/retry:
@@ -329,6 +343,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CollectionJob'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
   /v1/reports:
     get:
       tags: [Reports]
@@ -344,6 +360,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ReportList'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
     post:
       tags: [Reports]
       operationId: createReport
@@ -364,6 +382,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Report'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
   /v1/reports/{reportId}:
     get:
       tags: [Reports]
@@ -381,6 +401,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Report'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
   /v1/reports/{reportId}/artifacts/{artifactFormat}:
@@ -401,6 +423,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ReportArtifact'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
   /v1/schedules:
@@ -418,6 +442,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ScheduleList'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
     post:
       tags: [Schedules]
       operationId: createSchedule
@@ -438,6 +464,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Schedule'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
   /v1/schedules/{scheduleId}:
     get:
       tags: [Schedules]
@@ -455,6 +483,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Schedule'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
     patch:
@@ -479,6 +509,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Schedule'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
   /v1/schedules/{scheduleId}/pause:
@@ -498,6 +530,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Schedule'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
   /v1/schedules/{scheduleId}/resume:
@@ -517,6 +551,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Schedule'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
   /v1/audit-events:
@@ -543,6 +579,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AuditEventList'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
 components:
   headers:
     XRequestID:
@@ -626,6 +664,7 @@ components:
           type: string
         permissions:
           type: array
+          maxItems: 32
           items:
             type: string
     AuthResponse:
@@ -808,6 +847,9 @@ components:
       properties:
         providers:
           type: array
+          minItems: 1
+          maxItems: 2
+          uniqueItems: true
           items:
             $ref: '#/components/schemas/ProviderType'
         month:
@@ -899,6 +941,9 @@ components:
           type: string
         formats:
           type: array
+          minItems: 1
+          maxItems: 4
+          uniqueItems: true
           items:
             $ref: '#/components/schemas/ReportFormat'
         jsonOutput:
@@ -975,6 +1020,9 @@ components:
           type: string
         providers:
           type: array
+          minItems: 1
+          maxItems: 2
+          uniqueItems: true
           items:
             $ref: '#/components/schemas/ProviderType'
     ScheduleUpdateRequest:
@@ -988,6 +1036,8 @@ components:
           type: string
         providers:
           type: array
+          maxItems: 2
+          uniqueItems: true
           items:
             $ref: '#/components/schemas/ProviderType'
         nextRunAt:


### PR DESCRIPTION
## Summary
- sync the checked-in roadmap source-of-truth docs with the live Weeks 1-10 GitHub backlog
- expand `integrations/openapi/invoices.yaml` into the control-plane contract and include the current `GET /healthz` route
- keep `README.md` and `docs/USAGE.md` truthful to `main` while pointing to the new roadmap docs

## Scope
- source-of-truth docs and contract only
- no new runtime, API, or frontend behavior

## Validation
- `make test`
- pre-commit `pytest`
- `make verify` is currently blocked on the existing `apps/api-go` baseline module/import mismatch (`go vet ./...` fails because `go.mod` still declares `github.com/USERNAME/invoices-platform/apps/api-go` while code imports `github.com/vgeshiktor/...`)

## Why this PR first
- unblocks stacked PR `#91` by adding the missing `/healthz` OpenAPI contract entry required by the frontend contract check
- gives `main` the roadmap/source-of-truth docs before the implementation PR stack is restacked


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded planning roadmap with Weeks 1–10 implementation guidance
  * Added frontend backlog and release procedures documentation
  * Added telemetry taxonomy and request correlation standards
  * Updated API status and command references

* **New Features**
  * Control-plane API specification now includes authentication, provider configuration, collection jobs, report tracking, schedules, and audit events
  * X-Request-ID correlation headers added to API contract

<!-- end of auto-generated comment: release notes by coderabbit.ai -->