### PR TITLE
docs: align day 3 skill governance

### DIFF
--- a/.ai/README.md
+++ b/.ai/README.md
@@ -44,6 +44,14 @@
 - Use declarative or trusted-catalog UI contracts for generated UI work; do not treat arbitrary executable UI as acceptable output.
 - Keep AP2/UCP-style payment or procurement work in `commerce-deferred` until the repo has an explicit transaction surface and dedicated safeguards.
 
+## Skill Governance Review Gate
+
+- For skill-related work, use the existing task-packet fields rather than adding a skill-specific template.
+- Treat external-skill adoption work like dependency review: record source, pinned version, trust level, data scope, HITL approval point, and validation expectations.
+- Treat future repo-local skill authoring work as governed workflow design: record intended trigger surface, non-goals, helper assets/scripts, and portability assumptions in the same packet structure.
+- For production/shared skill work, `Success criteria / eval rubric` and `Required validation` should cover `trigger`, `execution`, `regression`, and `token budget`.
+- Keep skill governance proportional to current repo maturity: document and test the rules now, and defer runtime enforcement until the repo has an actual local skill library to govern.
+
 ## Guardrails
 
 - Keep task packets short and anchored to real repo files.

--- a/.ai/evals/tasks.yaml
+++ b/.ai/evals/tasks.yaml
@@ -286,6 +286,33 @@ legacy_review_templates:
       - Governance defaults clearly separate tools, collaborator agents, UI contracts, and deferred commerce work.
       - Repo contract tests protect the documented interoperability guardrails without adding telemetry requirements.
 
+  - id: day3-skill-governance-review
+    name: Review Day 3 skill governance defaults and skill-library guardrails
+    mode: production
+    reasoning_level: ai:review
+    scope: governance review of skill adoption and future skill-authoring defaults across repo rules, task packets, eval templates, contract tests, and security guidance
+    source_of_truth:
+      - AGENTS.md
+      - PLANS.md
+      - .ai/README.md
+      - .ai/evals/tasks.yaml
+      - .ai/tasks/2026-06-25-day3-skill-governance.md
+      - docs/SECURITY-AND-DATA-HANDLING.md
+      - tests/test_repo_verify_contract.py
+    rubric:
+      - AGENTS.md vs Skills vs MCP/tool boundaries stay explicit
+      - source selection and pinning rules stay reviewable
+      - progressive disclosure and portability rules remain discoverable
+      - trigger, execution, regression, and token-budget expectations stay explicit
+    ship_gate: skill governance must stay repo-backed, reviewable, and non-speculative
+    required_validation:
+      - Check that repo guidance distinguishes always-on `AGENTS.md` rules from on-demand skills and external tools/MCPs.
+      - Check that adoption rules cover trusted sources, pinned versions, and review before shared use.
+      - Flag unsupported policy claims, missing review gates, or doc/test drift.
+    success_criteria:
+      - Skill governance stays proportional to repo maturity and does not invent a repo-local runtime.
+      - Repo contract tests protect the documented defaults without adding telemetry or runtime enforcement.
+
 p1_after_first_hardening_pr:
   - Add property-based tests for deduplication, date intervals, and monetary calculations.
   - Validate the OpenAPI draft against actual implementation boundaries.

--- a/.ai/tasks/2026-06-25-day3-skill-governance.md
+++ b/.ai/tasks/2026-06-25-day3-skill-governance.md
@@ -1,0 +1,64 @@
+# Task Packet
+Desired outcome:
+Align repo governance artifacts with Day 3 skill-governance guidance without adding a repo-local skill library, runtime enforcement, or product-surface changes.
+Explicit non-goals:
+- No repo-local `SKILL.md` creation.
+- No runtime routing, skill linting, telemetry, or CI execution changes.
+- No benchmark result rows in `.ai/evals/results.csv`.
+Relevant docs/files:
+- `AGENTS.md`
+- `PLANS.md`
+- `.ai/README.md`
+- `.ai/evals/tasks.yaml`
+- `docs/SECURITY-AND-DATA-HANDLING.md`
+- `tests/test_repo_verify_contract.py`
+Required validation:
+- `pytest -q tests/test_repo_verify_contract.py`
+Known decisions:
+- Scope is governance-only.
+- This pass covers both external-skill adoption and future repo-local skill authoring standards.
+- Enforcement stays at the docs/contract-test enforcement only layer.
+Missing decisions:
+- None for this pass.
+Working mode: `production`
+Success criteria / eval rubric:
+- Repo rules clearly distinguish `AGENTS.md`, Skills, and tools/MCP surfaces.
+- Source selection, pinning, progressive disclosure, and portability rules remain repo-backed and reviewable.
+- Skill-governance expectations define `trigger`, `execution`, `regression`, and `token budget` coverage without inventing runtime enforcement.
+AI-specific review focus:
+- Unsupported governance claims
+- Missing review gates or pinned-dependency expectations
+- Drift between docs, task packet, eval catalog, security guidance, and contract tests
+Harness components touched:
+- instructions/guardrails
+- task memory/spec
+- eval contracts
+- security guidance
+- validation/tools
+Integration mode: `tool`
+External dependency or registry:
+- official guidance source: `Agent Skills_Day_3.pdf` recommendations plus existing repo governance files
+Trust level: `official`
+Data scope: `sanitized`
+HITL approval point:
+- Before any future action-allowed or sensitive skill is adopted for shared workflows
+Write permission / read-only expectation:
+- Governance docs are writable; external or real-data skill usage should default to read-only when unavoidable
+Transport/schema debugging plan:
+- Keep this pass at the governance layer; use repo docs and contract tests rather than runtime instrumentation
+Reasoning level: `ai:review`
+max initial files: `6`
+Overview/search plan:
+- Review the existing Day 1 and Day 2 governance assets first, then add only the Day 3 skill-governance deltas that fit the current repo maturity
+Lean-ctx structure check (`ctx_tree`) scope:
+- repo root, `.ai/`, and `docs/`
+Lean-ctx search plan (`ctx_search`):
+- skill, governance, eval, progressive disclosure, and security-handling terms
+Intended file reads (`ctx_read` / `ctx_multi_read`):
+- repo governance docs, eval catalog, security guidance, and repo contract tests
+Intended compressed shell commands (`ctx_shell` / `lean-ctx -c`):
+- `lean-ctx -c "pytest -q tests/test_repo_verify_contract.py"`
+Raw/native fallback justification:
+- Use raw/native access only if exact uncompressed output is needed to debug a lean-ctx or PDF-inspection limitation
+
+---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,17 @@ Use `.ai/` for task-scoped packets and evaluation inputs/results when work is su
 - For UI-generating work, allow declarative or trusted-catalog UI contracts rather than arbitrary generated executable UI.
 - Defer AP2/UCP-style payment or procurement flows until the repo has an explicit autonomous transaction surface and dedicated guardrails.
 
+## Skill Governance Defaults
+
+- Treat `AGENTS.md` as always-loaded repo guidance, Skills as on-demand procedural runbooks, and tools/MCP servers as the execution surfaces those runbooks can call.
+- Skills are for narrow, repeatable workflows. Always-on project conventions belong in `AGENTS.md`, not in a skill body.
+- For adoption, prefer first-party, internal, or otherwise vetted skills first. Pin adopted skills to a reviewed version or commit, review them like code, and do not use public or unverified skills as production dependencies.
+- Future repo-local skills should follow one skill, one job. If a workflow cannot be described in one sentence, split it before writing `SKILL.md`.
+- The description field is the routing interface and must state what it does, when to use it, and when not to use it.
+- Use progressive disclosure for long or edge-case material by moving it into `references/`, and keep deterministic helper logic in `scripts/` when the agent would otherwise keep re-deriving it.
+- Do not hard-code secrets, credentials, or machine-specific paths. Repo-local skills should stay portable across compliant runtimes.
+- For sensitive, side-effectful, or real-data work, skill usage inherits the existing HITL, read-only, and sanitized data expectations from this repo's interoperability and security guidance.
+
 ## AI Context Budget
 
 - Start with `README.md`, `docs/USAGE.md`, and the active task packet if present.

--- a/PLANS.md
+++ b/PLANS.md
@@ -59,4 +59,9 @@
   - expanded `.ai` task-packet and eval-review fields with trust level, data scope, HITL, and read-only expectations
   - added contract-test coverage so interoperability guardrails remain discoverable and hard to drift
   - explicitly deferred AP2/UCP-style commerce flows until the repo has a real autonomous transaction surface
+- `2026-06-25`: aligned repo governance with the Day 3 skill-governance guidance at the workflow layer:
+  - added repo-level defaults that distinguish `AGENTS.md`, Skills, and tools/MCP surfaces
+  - documented source-selection, pinning, progressive-disclosure, portability, and eval-coverage expectations for future skill work
+  - added a new day-3 governance task packet plus eval-catalog and contract-test coverage
+  - intentionally deferred repo-local skill creation, runtime enforcement, telemetry, and CI-driven skill execution until the repo has a real skill library to govern
 ---

--- a/docs/SECURITY-AND-DATA-HANDLING.md
+++ b/docs/SECURITY-AND-DATA-HANDLING.md
@@ -145,6 +145,16 @@ Not allowed:
 
 If a workflow needs a new outbound destination, document it before use and treat it as a security review point.
 
+## Skill Adoption and Data Exposure
+
+Treat third-party or public skills like executable dependencies.
+
+- third-party/public skills are treated like executable dependencies and must be reviewed before use
+- pinning and audit expectations apply before shared adoption
+- real or production data should not flow through public-prototype-only skills
+- if a skill will touch sensitive, side-effectful, or external-tool work, apply the repo's existing trust-level, HITL, and read-only rules before adoption
+- do not assume marketplace popularity is a security signal; prefer official, internal, or otherwise vetted sources and review what the skill can execute in your context
+
 ## Production Data Prohibition for Agent Evaluations
 
 Agent-evaluation and benchmark material must not use production data.

--- a/tests/test_repo_verify_contract.py
+++ b/tests/test_repo_verify_contract.py
@@ -11,6 +11,9 @@ EVAL_TASKS = ROOT / ".ai" / "evals" / "tasks.yaml"
 DAY2_INTEROP_TASK_PACKET = (
     ROOT / ".ai" / "tasks" / "2026-06-21-day2-interoperability-governance.md"
 )
+DAY3_SKILL_GOVERNANCE_TASK_PACKET = (
+    ROOT / ".ai" / "tasks" / "2026-06-25-day3-skill-governance.md"
+)
 
 
 def _read(path: Path) -> str:
@@ -58,6 +61,7 @@ def test_repo_governance_docs_define_lean_ctx_workflow_contract():
     task_packet_template = _read(TASK_PACKET_TEMPLATE)
     eval_tasks = _read(EVAL_TASKS)
     day2_task_packet = _read(DAY2_INTEROP_TASK_PACKET)
+    day3_task_packet = _read(DAY3_SKILL_GOVERNANCE_TASK_PACKET)
 
     assert "## Agentic Engineering Defaults" in agents_guide
     assert "working mode: `prototype` for exploration or `production`" in agents_guide
@@ -81,6 +85,22 @@ def test_repo_governance_docs_define_lean_ctx_workflow_contract():
     )
     assert "declarative or trusted-catalog UI contracts" in agents_guide
     assert "Defer AP2/UCP-style payment or procurement flows" in agents_guide
+    assert "## Skill Governance Defaults" in agents_guide
+    assert "Skills are for narrow, repeatable workflows" in agents_guide
+    assert "Always-on project conventions belong in `AGENTS.md`" in agents_guide
+    assert "first-party, internal, or otherwise vetted skills first" in agents_guide
+    assert "Pin adopted skills to a reviewed version or commit" in agents_guide
+    assert "one skill, one job" in agents_guide
+    assert "what it does, when to use it, and when not to use it" in agents_guide
+    assert "progressive disclosure" in agents_guide
+    assert "deterministic helper logic in `scripts/`" in agents_guide
+    assert (
+        "Do not hard-code secrets, credentials, or machine-specific paths"
+        in agents_guide
+    )
+    assert "portable across compliant runtimes" in agents_guide
+    assert "read-only" in agents_guide
+    assert "sanitized" in agents_guide
 
     assert "## Lean-ctx Workflow" in agents_guide
     assert "start with `ctx_overview`" in agents_guide
@@ -123,6 +143,14 @@ def test_repo_governance_docs_define_lean_ctx_workflow_contract():
     )
     assert "read-only scope when possible" in ai_readme
     assert "HITL approval point" in ai_readme
+    assert "## Skill Governance Review Gate" in ai_readme
+    assert (
+        "use the existing task-packet fields rather than adding a skill-specific template"
+        in ai_readme
+    )
+    assert "external-skill adoption work" in ai_readme
+    assert "future repo-local skill authoring work" in ai_readme
+    assert "`trigger`, `execution`, `regression`, and `token budget`" in ai_readme
 
     assert "Working mode: `prototype | production`" in task_packet_template
     assert "Success criteria / eval rubric:" in task_packet_template
@@ -165,6 +193,11 @@ def test_repo_governance_docs_define_lean_ctx_workflow_contract():
     assert "Contract coverage protects the policy" in eval_tasks
     assert "- id: agentic-alignment-governance-review" in eval_tasks
     assert "- id: day2-interoperability-governance-review" in eval_tasks
+    assert "- id: day3-skill-governance-review" in eval_tasks
+    assert (
+        "Review Day 3 skill governance defaults and skill-library guardrails"
+        in eval_tasks
+    )
     assert (
         "Review Day 2 interoperability governance defaults and guardrails" in eval_tasks
     )
@@ -173,6 +206,15 @@ def test_repo_governance_docs_define_lean_ctx_workflow_contract():
         in eval_tasks
     )
     assert "HITL, trust level, and real-data scope rules remain aligned" in eval_tasks
+    assert "AGENTS.md vs Skills vs MCP/tool boundaries stay explicit" in eval_tasks
+    assert "source selection and pinning rules stay reviewable" in eval_tasks
+    assert (
+        "progressive disclosure and portability rules remain discoverable" in eval_tasks
+    )
+    assert (
+        "trigger, execution, regression, and token-budget expectations stay explicit"
+        in eval_tasks
+    )
     assert (
         "unsupported policy claims, missing review gates, or doc/test drift"
         in eval_tasks
@@ -185,3 +227,12 @@ def test_repo_governance_docs_define_lean_ctx_workflow_contract():
     assert "HITL approval point:" in day2_task_packet
     assert "Write permission / read-only expectation:" in day2_task_packet
     assert "Transport/schema debugging plan:" in day2_task_packet
+
+    assert "Desired outcome:" in day3_task_packet
+    assert "governance-only" in day3_task_packet
+    assert "Working mode: `production`" in day3_task_packet
+    assert "External dependency or registry:" in day3_task_packet
+    assert "official guidance source" in day3_task_packet
+    assert "docs/contract-test enforcement only" in day3_task_packet
+    assert "Trust level: `official`" in day3_task_packet
+    assert "Data scope: `sanitized`" in day3_task_packet


### PR DESCRIPTION
## Summary
- add repo-level skill governance defaults for AGENTS.md vs Skills vs tools/MCPs
- add day-3 task, eval, security, and plans coverage
- extend repo contract tests for the new governance rules

## Test Plan
- pytest -q tests/test_repo_verify_contract.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear governance guidance for how skills are described, adopted, and reviewed.
  * Expanded security and data-handling rules for using third-party or public skills.
  * Added coverage to keep skill-related documentation and review checks aligned across the repo.

* **Bug Fixes**
  * Strengthened consistency checks so the documented governance rules stay in sync with required review criteria and validation expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->