### PR TITLE
docs: align day 4 security and evaluation governance

### DIFF
--- a/.ai/README.md
+++ b/.ai/README.md
@@ -52,6 +52,14 @@
 - For production/shared skill work, `Success criteria / eval rubric` and `Required validation` should cover `trigger`, `execution`, `regression`, and `token budget`.
 - Keep skill governance proportional to current repo maturity: document and test the rules now, and defer runtime enforcement until the repo has an actual local skill library to govern.
 
+## Security and Evaluation Review Gate
+
+- Use `Trust level`, `Data scope`, `HITL approval point`, and `Write permission / read-only expectation` to encode the security posture for agentic work.
+- Use `Success criteria / eval rubric` and `Required validation` to encode the evaluation posture for agentic work.
+- For production/shared agent work, review the seven evaluation dimensions explicitly: intent satisfaction, functional correctness, visual and behavioral correctness, cost and efficiency, code quality and convention matching, trajectory quality, and self-repair behavior.
+- For this repo's current maturity, allowed evaluation method mix is automated functional testing, security/safety review, human review, and browser-based testing when UI changes exist.
+- Treat trace-level observability and internal-reasoning inspection as deferred prerequisites for richer glass-box evaluation, not current repo requirements.
+
 ## Guardrails
 
 - Keep task packets short and anchored to real repo files.

--- a/.ai/evals/tasks.yaml
+++ b/.ai/evals/tasks.yaml
@@ -313,6 +313,35 @@ legacy_review_templates:
       - Skill governance stays proportional to repo maturity and does not invent a repo-local runtime.
       - Repo contract tests protect the documented defaults without adding telemetry or runtime enforcement.
 
+  - id: day4-agent-security-evaluation-governance-review
+    name: Review Day 4 agent security and evaluation governance defaults
+    mode: production
+    reasoning_level: ai:review
+    scope: governance review of agent security posture and evaluation expectations across repo rules, task packets, eval templates, security guidance, and contract tests
+    source_of_truth:
+      - AGENTS.md
+      - PLANS.md
+      - .ai/README.md
+      - .ai/evals/tasks.yaml
+      - .ai/tasks/2026-06-28-day4-agent-security-evaluation-governance.md
+      - docs/SECURITY-AND-DATA-HANDLING.md
+      - tests/test_repo_verify_contract.py
+    rubric:
+      - supply-chain and dependency-adoption rules stay reviewable
+      - governed egress and non-interactive access expectations stay explicit
+      - high-risk action approval and plain-language review expectations remain documented
+      - security boundary checks remain distinct from shipping-quality evaluation
+      - the seven evaluation dimensions stay discoverable and repo-appropriate
+      - observability and scanner language stays deferred and non-speculative
+    ship_gate: day-4 security and evaluation governance must stay repo-backed, reviewable, and non-speculative
+    required_validation:
+      - Check that generated code, dependencies, and tools are treated as untrusted until verified.
+      - Check that evaluation guidance distinguishes shipping quality from boundary safety and reuses existing `.ai` fields.
+      - Flag unsupported policy claims, missing review gates, or doc/test drift.
+    success_criteria:
+      - Repo guidance captures the day-4 security posture without inventing runtime enforcement.
+      - Repo guidance captures the day-4 evaluation vocabulary without claiming current observability or scanner infrastructure.
+
 p1_after_first_hardening_pr:
   - Add property-based tests for deduplication, date intervals, and monetary calculations.
   - Validate the OpenAPI draft against actual implementation boundaries.

--- a/.ai/tasks/2026-06-28-day4-agent-security-evaluation-governance.md
+++ b/.ai/tasks/2026-06-28-day4-agent-security-evaluation-governance.md
@@ -1,0 +1,66 @@
+# Task Packet
+Desired outcome:
+Align repo governance artifacts with Day 4 agent security and evaluation guidance without adding runtime observability, new scanners, or product-surface changes.
+Explicit non-goals:
+- no runtime observability, sandboxing infrastructure, SAST/SCA setup, or online-eval rollout in this pass
+- No OpenTelemetry traces, AgBOMs, circuit breakers, or checkpoint infrastructure.
+- No benchmark result rows in `.ai/evals/results.csv`.
+Relevant docs/files:
+- `AGENTS.md`
+- `PLANS.md`
+- `.ai/README.md`
+- `.ai/evals/tasks.yaml`
+- `docs/SECURITY-AND-DATA-HANDLING.md`
+- `tests/test_repo_verify_contract.py`
+- `tests/test_eval_catalog_contract.py`
+Required validation:
+- `pytest -q tests/test_repo_verify_contract.py tests/test_eval_catalog_contract.py`
+Known decisions:
+- Scope is governance-only.
+- This pass covers both agent security and evaluation guidance.
+- Enforcement stays at the docs/contract-test enforcement only layer.
+- Existing `.ai` fields remain sufficient; no template expansion in this pass.
+Missing decisions:
+- None for this pass.
+Working mode: `production`
+Success criteria / eval rubric:
+- Repo guidance documents a security posture for untrusted generated code, governed egress, narrow permissions, and high-risk approvals.
+- Repo guidance documents evaluation expectations for intent, correctness, convention matching, trajectory quality, and self-repair without inventing runtime telemetry.
+- Day-4 language stays repo-backed and clearly distinguishes current governance rules from deferred future infrastructure.
+AI-specific review focus:
+- Unsupported security or observability claims
+- Missing separation between boundary safety and shipping quality
+- Drift between docs, task packet, eval catalog, security guidance, and contract tests
+Harness components touched:
+- instructions/guardrails
+- task memory/spec
+- eval contracts
+- security guidance
+- validation/tools
+Integration mode: `tool`
+External dependency or registry:
+- official guidance source: `Vibe Coding Agent Security and Evaluation_Day_4.pdf` plus existing repo governance files
+Trust level: `official`
+Data scope: `sanitized`
+HITL approval point:
+- Before any high-risk or irreversible action, especially when generated code or new dependencies would touch sensitive systems or non-read-only data
+Write permission / read-only expectation:
+- Governance docs are writable; autonomous or AI-assisted sensitive work should default to bounded read-only or non-production scopes when possible
+Transport/schema debugging plan:
+- Keep this pass at the governance layer; do not introduce runtime tracing or scanner infrastructure in this change
+Reasoning level: `ai:review`
+max initial files: `6`
+Overview/search plan:
+- Review existing day 1-3 governance assets first, then add only the day-4 security and evaluation deltas that fit current repo maturity
+Lean-ctx structure check (`ctx_tree`) scope:
+- repo root, `.ai/`, `docs/`, and `tests/`
+Lean-ctx search plan (`ctx_search`):
+- security, evaluation, observability, scanner, egress, trust, and trajectory terms
+Intended file reads (`ctx_read` / `ctx_multi_read`):
+- repo governance docs, eval catalog, security guidance, and repo contract tests
+Intended compressed shell commands (`ctx_shell` / `lean-ctx -c`):
+- `lean-ctx -c "pytest -q tests/test_repo_verify_contract.py tests/test_eval_catalog_contract.py"`
+Raw/native fallback justification:
+- Use raw/native access only if exact uncompressed output is needed to debug a lean-ctx or PDF-inspection limitation
+
+---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,16 @@ Use `.ai/` for task-scoped packets and evaluation inputs/results when work is su
 - Do not hard-code secrets, credentials, or machine-specific paths. Repo-local skills should stay portable across compliant runtimes.
 - For sensitive, side-effectful, or real-data work, skill usage inherits the existing HITL, read-only, and sanitized data expectations from this repo's interoperability and security guidance.
 
+## Agent Security and Evaluation Defaults
+
+- generated code, generated dependencies, and new tools are untrusted until verified; check them against repo policy, tests, and security guidance before shared use
+- Prefer vetted registries, explicit pinning, and review-before-adoption for packages, tools, and generated integrations to reduce hallucinated-package and slopsquatting risk.
+- Keep external access non-interactive and governed. Do not let autonomous workflows browse or fetch arbitrary public resources outside documented repo workflows and approved access paths.
+- keep permissions narrow, default sensitive work to read-only or non-production scopes, and require human approval for high-risk or irreversible actions
+- require small, reviewable change batches so failures stay inspectable and rollback remains tractable
+- Reject success claims that depend on deleting, weakening, or mocking tests instead of fixing the underlying behavior.
+- Distinguish safety/security from shipping quality: staying inside the boundary is not enough to claim success if intent, correctness, or repo conventions drift.
+
 ## AI Context Budget
 
 - Start with `README.md`, `docs/USAGE.md`, and the active task packet if present.

--- a/PLANS.md
+++ b/PLANS.md
@@ -64,4 +64,9 @@
   - documented source-selection, pinning, progressive-disclosure, portability, and eval-coverage expectations for future skill work
   - added a new day-3 governance task packet plus eval-catalog and contract-test coverage
   - intentionally deferred repo-local skill creation, runtime enforcement, telemetry, and CI-driven skill execution until the repo has a real skill library to govern
+- `2026-06-28`: aligned repo governance with the Day 4 agent security and evaluation guidance at the workflow layer:
+  - added repo-level defaults for untrusted generated code, governed egress, narrow permissions, and high-risk approvals
+  - documented evaluation vocabulary for intent satisfaction, correctness, convention matching, trajectory quality, and self-repair behavior
+  - extended governance assets and contract coverage without changing the `.ai` template shape
+  - intentionally deferred runtime observability, security scanners, circuit breakers, and agent checkpoint infrastructure until the repo has real runtime surfaces to govern
 ---

--- a/docs/SECURITY-AND-DATA-HANDLING.md
+++ b/docs/SECURITY-AND-DATA-HANDLING.md
@@ -155,6 +155,16 @@ Treat third-party or public skills like executable dependencies.
 - if a skill will touch sensitive, side-effectful, or external-tool work, apply the repo's existing trust-level, HITL, and read-only rules before adoption
 - do not assume marketplace popularity is a security signal; prefer official, internal, or otherwise vetted sources and review what the skill can execute in your context
 
+## Agentic Security Posture for Generated Changes
+
+Generated dependencies and packages must come from vetted or pinned sources before shared use.
+
+- generated dependencies and packages must come from vetted or pinned sources before shared adoption
+- public internet or tool access should remain governed and non-interactive where possible; do not let autonomous workflows fetch arbitrary public resources outside documented repo workflows
+- autonomous or AI-assisted work must not inherit broad ambient authority for sensitive actions; prefer bounded, task-scoped access and read-only or non-production scopes where possible
+- high-risk actions require structured human review with a plain-language explanation of what will change before approval
+- user corrections, screenshots, and evaluation evidence remain subject to the existing redaction and sanitized-data rules in this document
+
 ## Production Data Prohibition for Agent Evaluations
 
 Agent-evaluation and benchmark material must not use production data.

--- a/tests/test_repo_verify_contract.py
+++ b/tests/test_repo_verify_contract.py
@@ -14,6 +14,9 @@ DAY2_INTEROP_TASK_PACKET = (
 DAY3_SKILL_GOVERNANCE_TASK_PACKET = (
     ROOT / ".ai" / "tasks" / "2026-06-25-day3-skill-governance.md"
 )
+DAY4_AGENT_SECURITY_EVAL_TASK_PACKET = (
+    ROOT / ".ai" / "tasks" / "2026-06-28-day4-agent-security-evaluation-governance.md"
+)
 
 
 def _read(path: Path) -> str:
@@ -62,6 +65,7 @@ def test_repo_governance_docs_define_lean_ctx_workflow_contract():
     eval_tasks = _read(EVAL_TASKS)
     day2_task_packet = _read(DAY2_INTEROP_TASK_PACKET)
     day3_task_packet = _read(DAY3_SKILL_GOVERNANCE_TASK_PACKET)
+    day4_task_packet = _read(DAY4_AGENT_SECURITY_EVAL_TASK_PACKET)
 
     assert "## Agentic Engineering Defaults" in agents_guide
     assert "working mode: `prototype` for exploration or `production`" in agents_guide
@@ -101,6 +105,22 @@ def test_repo_governance_docs_define_lean_ctx_workflow_contract():
     assert "portable across compliant runtimes" in agents_guide
     assert "read-only" in agents_guide
     assert "sanitized" in agents_guide
+    assert "## Agent Security and Evaluation Defaults" in agents_guide
+    assert (
+        "generated code, generated dependencies, and new tools are untrusted until verified"
+        in agents_guide
+    )
+    assert (
+        "Prefer vetted registries, explicit pinning, and review-before-adoption"
+        in agents_guide
+    )
+    assert "Keep external access non-interactive and governed" in agents_guide
+    assert "keep permissions narrow" in agents_guide
+    assert (
+        "require human approval for high-risk or irreversible actions" in agents_guide
+    )
+    assert "small, reviewable change batches" in agents_guide
+    assert "staying inside the boundary is not enough to claim success" in agents_guide
 
     assert "## Lean-ctx Workflow" in agents_guide
     assert "start with `ctx_overview`" in agents_guide
@@ -151,6 +171,20 @@ def test_repo_governance_docs_define_lean_ctx_workflow_contract():
     assert "external-skill adoption work" in ai_readme
     assert "future repo-local skill authoring work" in ai_readme
     assert "`trigger`, `execution`, `regression`, and `token budget`" in ai_readme
+    assert "## Security and Evaluation Review Gate" in ai_readme
+    assert "`Trust level`, `Data scope`, `HITL approval point`" in ai_readme
+    assert "`Success criteria / eval rubric` and `Required validation`" in ai_readme
+    assert "intent satisfaction" in ai_readme
+    assert "visual and behavioral correctness" in ai_readme
+    assert "trajectory quality" in ai_readme
+    assert "self-repair behavior" in ai_readme
+    assert "automated functional testing" in ai_readme
+    assert "security/safety review" in ai_readme
+    assert "browser-based testing when UI changes exist" in ai_readme
+    assert (
+        "trace-level observability and internal-reasoning inspection as deferred prerequisites"
+        in ai_readme
+    )
 
     assert "Working mode: `prototype | production`" in task_packet_template
     assert "Success criteria / eval rubric:" in task_packet_template
@@ -194,9 +228,13 @@ def test_repo_governance_docs_define_lean_ctx_workflow_contract():
     assert "- id: agentic-alignment-governance-review" in eval_tasks
     assert "- id: day2-interoperability-governance-review" in eval_tasks
     assert "- id: day3-skill-governance-review" in eval_tasks
+    assert "- id: day4-agent-security-evaluation-governance-review" in eval_tasks
     assert (
         "Review Day 3 skill governance defaults and skill-library guardrails"
         in eval_tasks
+    )
+    assert (
+        "Review Day 4 agent security and evaluation governance defaults" in eval_tasks
     )
     assert (
         "Review Day 2 interoperability governance defaults and guardrails" in eval_tasks
@@ -213,6 +251,23 @@ def test_repo_governance_docs_define_lean_ctx_workflow_contract():
     )
     assert (
         "trigger, execution, regression, and token-budget expectations stay explicit"
+        in eval_tasks
+    )
+    assert "supply-chain and dependency-adoption rules stay reviewable" in eval_tasks
+    assert (
+        "governed egress and non-interactive access expectations stay explicit"
+        in eval_tasks
+    )
+    assert (
+        "high-risk action approval and plain-language review expectations remain documented"
+        in eval_tasks
+    )
+    assert (
+        "security boundary checks remain distinct from shipping-quality evaluation"
+        in eval_tasks
+    )
+    assert (
+        "observability and scanner language stays deferred and non-speculative"
         in eval_tasks
     )
     assert (
@@ -236,3 +291,15 @@ def test_repo_governance_docs_define_lean_ctx_workflow_contract():
     assert "docs/contract-test enforcement only" in day3_task_packet
     assert "Trust level: `official`" in day3_task_packet
     assert "Data scope: `sanitized`" in day3_task_packet
+
+    assert "Desired outcome:" in day4_task_packet
+    assert "governance-only" in day4_task_packet
+    assert "Working mode: `production`" in day4_task_packet
+    assert "official guidance source" in day4_task_packet
+    assert "docs/contract-test enforcement only" in day4_task_packet
+    assert (
+        "no runtime observability, sandboxing infrastructure, SAST/SCA setup, or online-eval rollout"
+        in day4_task_packet
+    )
+    assert "Trust level: `official`" in day4_task_packet
+    assert "Data scope: `sanitized`" in day4_task_packet


### PR DESCRIPTION
## Summary
- add day-4 agent security and evaluation defaults to repo governance docs
- document the security and evaluation review gate in `.ai/README.md` without changing the task packet template
- add the day-4 task packet and eval catalog coverage, then extend contract tests to keep the governance language discoverable

## Test Plan
- [x] pytest -q tests/test_repo_verify_contract.py tests/test_eval_catalog_contract.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added updated guidance for agent security and evaluation expectations across repository docs and task planning materials.
  * Introduced a new review template and task packet covering Day 4 security and evaluation governance.

* **Bug Fixes**
  * Expanded repository checks to validate the new guidance and keep documentation aligned.
  * Clarified acceptable evaluation criteria and review expectations to reduce inconsistent documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->